### PR TITLE
Improve pane contents retrieval

### DIFF
--- a/tmux-extrakto
+++ b/tmux-extrakto
@@ -16,7 +16,7 @@ if [ -z "$CLIP" ]; then
   esac
 fi
 
-tmux set-buffer -- `tmux capture-pane -pS -32768 -t !|$DIR/extrakto.py $1|fzf`
+tmux set-buffer -- `tmux capture-pane -pJ -t !|$DIR/extrakto.py $1|fzf`
 
 if [ $? -eq 0 ]; then
   case $2 in


### PR DESCRIPTION
Added `-J` to fix handling of wrapped lines (I mentioned this issue in item 4 [here](https://github.com/laktak/extrakto/issues/1#issuecomment-331310748))

Removed `-S` to capture only visible content. This is open for discussion, I personally think I'll never want to search and copy/insert something that I don't currently see on the screen, so this change will cleanup the suggestions list.

Opinions? 🙂