### PR TITLE
Add tests for urls and paths

### DIFF
--- a/extrakto.py
+++ b/extrakto.py
@@ -2,71 +2,118 @@
 
 import sys
 import re
-import argparse
+
+from argparse import ArgumentParser
 from collections import OrderedDict
 
-parser = argparse.ArgumentParser(description='Extracts tokens from plaintext.')
-parser.add_argument('-p', help='extract path tokens', action='store_true')
-parser.add_argument('-u', help='extract url tokens', action='store_true')
-parser.add_argument('-w', help='extract word tokens', action='store_true')
-parser.add_argument('-r', help='reverse output', action='store_true')
-parser.add_argument('-m', '--min-length',
-                    help='minimum token length', default=5)
-args = parser.parse_args()
+RE_PATH = (
+    r'(?=[ \t\n]|"|\(|\[|<|\')?'
+    '(~/|/)?'
+    '([-a-zA-Z0-9_+-,.]+/[^ \t\n\r|:"\'$%&)>\]]*)'
+)
 
-# regexes fro extraction
-REPATH = r'(?=[ \t\n]|"|\(|\[|<|\')?(~/|/)?([-a-zA-Z0-9_+-,.]+/[^ \t\n\r|:"\'$%&)>\]]*)'
-REURL = r"(https?://|git@|git://|ssh://|ftp://|file:///)[a-zA-Z0-9?=%/_.:,;~@!#$&()*+-]*"
-REWORD = r'[^][(){} \t\n\r]+'
+RE_URL = (r"(https?://|git@|git://|ssh://|s*ftp://|file:///)"
+          "[a-zA-Z0-9?=%/_.:,;~@!#$&()*+-]*")
+
+RE_URL_OR_PATH = RE_PATH + "|" + RE_URL
+
+RE_WORD = r'[^][(){} \t\n\r]+'
+
+# reg exp to exclude transfer speeds like 5k/s or m/s, and page 1/2
+RE_SPEED = r'[kmgKMG]/s$|^\d+/\d+$'
+
+
+def get_args():
+    parser = ArgumentParser(description='Extracts tokens from plaintext.')
+
+    parser.add_argument('-p', '--paths', action='store_true',
+                        help='extract path tokens')
+
+    parser.add_argument('-u', '--urls', action='store_true',
+                        help='extract url tokens')
+
+    parser.add_argument('-w', '--words', action='store_true',
+                        help='extract word tokens')
+
+    parser.add_argument('-r', '--reverse', action='store_true',
+                        help='reverse output')
+
+    parser.add_argument('-m', '--min-length', default=5,
+                        help='minimum token length')
+
+    args = parser.parse_args()
+
+    return args
 
 
 def processUP(find, text, ml):
     res = list()
-    for m in re.finditer(find, "\n" + text):
+
+    for m in re.finditer(find, "\n" + text, flags=re.I):
         item = m.group()
         if item[-1] == ',' or item[-1] == ')':
             item = item[:-1]  # possible markdown link
+
         # hack to exclude transfer speeds like 5k/s or m/s, and page 1/2
-        if not re.search(r'[kmgKMG]/s$|^\d+/\d+$', item, re.I):
+        if not re.search(RE_SPEED, item, re.I):
             if len(item) > ml:
                 res.append(item)
     return res
 
 
-def processW(find, text, ml):
-    res = list()
-    for m in re.finditer(find, "\n" + text):
+def get_urls(text, ml=0):
+    return processUP(RE_URL, text, ml)
+
+
+def get_paths(text, ml=0):
+    return processUP(RE_PATH, text, ml)
+
+
+def get_urls_or_paths(text, ml=0):
+    return processUP(RE_URL_OR_PATH, text, ml)
+
+
+def get_words(text, ml):
+    words = []
+
+    for m in re.finditer(RE_WORD, "\n" + text):
         item = m.group().strip(',.:;()[]{}<>\'"')
         if len(item) > ml:
-            res.append(item)
-    return res
+            words.append(item)
+
+    return words
 
 
-def getInput():
+def get_input():
     return sys.stdin.read()
 
-if args.w:
-    # extract words
-    res = processW(REWORD, getInput(), args.min_length)
 
-elif args.p:
-    # extract path tokens
-    if args.u:
-        res = processUP(REPATH + "|" + REURL, getInput(), args.min_length)
+def main():
+    args = get_args()
+
+    if args.words:
+        res = get_words(get_input(), args.min_length)
+
+    elif args.paths:
+        if args.urls:
+            res = get_urls_or_paths(get_input(), args.min_length)
+        else:
+            res = get_paths(get_input(), args.min_length)
+
+    elif args.urls:
+        res = get_urls(get_input(), args.min_length)
+
     else:
-        res = processUP(REPATH, getInput(), args.min_length)
+        print('unknown option, see --help')
+        sys.exit(1)
 
-elif args.u:
-    # extract urls
-    res = processUP(REURL, getInput(), args.min_length)
+    if args.reverse:
+        res.reverse()
 
-else:
-    print('unknown option, see --help')
-    sys.exit(1)
+    # remove duplicates and print
+    for item in OrderedDict.fromkeys(res):
+        print(item)
 
-if args.r:
-    res.reverse()
 
-# remove duplicates and print
-for item in OrderedDict.fromkeys(res):
-    print(item)
+if __name__ == "__main__":
+    main()

--- a/tests/test_get_paths.py
+++ b/tests/test_get_paths.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from extrakto import get_paths
+
+
+class TestGetPaths(unittest.TestCase):
+
+    def test_match_tilde_path(self):
+        text = "hey, test ~/tmp/test.txt etc..."
+        urls = ["~/tmp/test.txt"]
+
+        result = get_paths(text)
+        self.assertEquals(urls, result)
+
+    def test_match_full_path(self):
+        text = "hey, open this file /home/joe/test.txt etc..."
+        urls = ["/home/joe/test.txt"]
+
+        result = get_paths(text)
+        self.assertEquals(urls, result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_get_urls.py
+++ b/tests/test_get_urls.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from extrakto import get_urls
+
+
+class TestGetURLs(unittest.TestCase):
+
+    def test_match_http(self):
+        text = "hey, open this url http://google.com etc..."
+        urls = ["http://google.com"]
+
+        result = get_urls(text)
+        self.assertEquals(urls, result)
+
+    def test_match_https(self):
+        text = "hey, open this secure url https://google.com etc..."
+        urls = ["https://google.com"]
+
+        result = get_urls(text)
+        self.assertEquals(urls, result)
+
+    def test_match_ftp(self):
+        text = "hey, connect to this server ftp://myserver.com etc..."
+        urls = ["ftp://myserver.com"]
+
+        result = get_urls(text)
+        self.assertEquals(urls, result)
+
+    def test_match_sftp(self):
+        text = "hey, connect to this secure server sftp://myserver.com etc..."
+        urls = ["sftp://myserver.com"]
+
+        result = get_urls(text)
+        self.assertEquals(urls, result)
+
+    def test_match_home_path(self):
+        text = "hey, open this file file:////home/joe etc..."
+        urls = ["file:////home/joe"]
+
+        result = get_urls(text)
+        self.assertEquals(urls, result)
+
+    def test_match_git(self):
+        text = ("hey, check out this repo git@github.com:laktak/extrakto.git"
+                ", it's a great tmux plugin")
+        urls = ["git@github.com:laktak/extrakto.git"]
+
+        result = get_urls(text)
+        self.assertEquals(urls, result)
+
+    def test_match_HTTP(self):
+        text = "hey, open this url HTTP://GOOGLE.COM etc..."
+        urls = ["HTTP://GOOGLE.COM"]
+
+        result = get_urls(text)
+        self.assertEquals(urls, result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi there, I noticed a bug on the pattern matching, not supporting UPPER CASE urls.
Also, I found out that there was no 'sftp' prefix on the regular expression for that matter.

I wondered which other cases I may be missing and I think that it would be a good idea to have tests to see what works and what doesn't. After starting with tests I realized that I had to make several changes to the code for them to work and be easily understandable.

I hope you don't mind the many changes I made to your code, if so, please let me know and I can fix whatever you think is best.

This doesn't require any extra dependency, you can run them as (for example) `python -m tests/test_get_urls`.

Here is an example output of what this PR adds:
```
➜ python -m tests/test_get_urls -v
test_match_HTTP (__main__.TestGetURLs) ... ok
test_match_ftp (__main__.TestGetURLs) ... ok
test_match_git (__main__.TestGetURLs) ... ok
test_match_home_path (__main__.TestGetURLs) ... ok
test_match_http (__main__.TestGetURLs) ... ok
test_match_https (__main__.TestGetURLs) ... ok
test_match_sftp (__main__.TestGetURLs) ... ok

----------------------------------------------------------------------
Ran 7 tests in 0.001s

OK

➜ python -m tests/test_get_paths -v
test_match_full_path (__main__.TestGetPaths) ... ok
test_match_tilde_path (__main__.TestGetPaths) ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.001s

OK
```

If you want, you can use a test runner to simplify the task of running all the tests, I recommend you `pytest`, this is an output using it:

```
➜ pytest -v
============================= test session starts =============================
[...trimmed output...]

tests/test_get_paths.py::TestGetPaths::test_match_full_path PASSED
tests/test_get_paths.py::TestGetPaths::test_match_tilde_path PASSED
tests/test_get_urls.py::TestGetURLs::test_match_HTTP PASSED
tests/test_get_urls.py::TestGetURLs::test_match_ftp PASSED
tests/test_get_urls.py::TestGetURLs::test_match_git PASSED
tests/test_get_urls.py::TestGetURLs::test_match_home_path PASSED
tests/test_get_urls.py::TestGetURLs::test_match_http PASSED
tests/test_get_urls.py::TestGetURLs::test_match_https PASSED
tests/test_get_urls.py::TestGetURLs::test_match_sftp PASSED

========================== 9 passed in 0.02 seconds ===========================
```

Changes list:

* move the functionality to main(), otherwise that gets executed when the tests are run,
* add long-style arguments to use more sane names of picked options,
* separate the regular expresions into multiple lines for pep8,
* add "sftp" protocol to url regular expression
* match HTTP as well as http and so on, this required to use `re.I`
* add functions with clear goal names to ease usability from tests