### PR TITLE
Add options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,22 @@ You should now have all `extrakto` key bindings defined.
 ### Options
 
 ```
+# Note: these are the default options
 set -g @extrakto_clip_key 'e'
 set -g @extrakto_clip_opt 'wr'
 set -g @extrakto_insert_key 'tab'
 set -g @extrakto_insert_opt 'wr'
+set -g @extrakto_window_split_direction 'v'
+set -g @extrakto_window_lines '6'
 ```
 - @extrakto_clip_key: the key binding to copy to the clipboard
 - @extrakto_clip_opt: the extract options when copying
 - @extrakto_insert_key: the key binding to insert to the current pane
 - @extrakto_insert_opt: the extract options when inserting
+- @extrakto_window_split_direction: whether the tmux split will be 'v'ertical or 'h'orizontal
+- @extrakto_window_lines: the size (in lines) of the tmux split
 
-Available options are:
+Available options for `extrakto_clip_opt` and `extrakto_insert_opt` are:
 - `p` extract path tokens
 - `u` extract url tokens
 - `w` extract word tokens

--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ set -g @extrakto_clip_key 'e'
 set -g @extrakto_clip_opt 'wr'
 set -g @extrakto_insert_key 'tab'
 set -g @extrakto_insert_opt 'wr'
-set -g @extrakto_window_split_direction 'v'
-set -g @extrakto_window_lines '6'
+set -g @extrakto_split_direction 'v'
+set -g @extrakto_split_size '6'
 ```
 - @extrakto_clip_key: the key binding to copy to the clipboard
 - @extrakto_clip_opt: the extract options when copying
 - @extrakto_insert_key: the key binding to insert to the current pane
 - @extrakto_insert_opt: the extract options when inserting
-- @extrakto_window_split_direction: whether the tmux split will be 'v'ertical or 'h'orizontal
-- @extrakto_window_lines: the size (in lines) of the tmux split
+- @extrakto_split_direction: whether the tmux split will be 'v'ertical or 'h'orizontal
+- @extrakto_split_size: the size of the tmux split
 
 Available options for `extrakto_clip_opt` and `extrakto_insert_opt` are:
 - `p` extract path tokens

--- a/extrakto.tmux
+++ b/extrakto.tmux
@@ -18,5 +18,15 @@ INSERT_KEY=${extrakto_insert_key:-$default_insert_key}
 default_insert_opt="wr"
 extrakto_insert_opt=$(tmux show-option -gqv "@extrakto_insert_opt")
 INSERT_OPT=${extrakto_insert_opt:-$default_insert_opt}
-tmux bind-key ${CLIP_KEY} split-window -v -l 6 "$CURRENT_DIR/tmux-extrakto -${CLIP_OPT} clip"
-tmux bind-key ${INSERT_KEY} split-window -v -l 6 "$CURRENT_DIR/tmux-extrakto -${INSERT_OPT} insert"
+
+default_window_split_direction="v"
+extrakto_window_split_direction=$(tmux show-option -gqv "@extrakto_window_split_direction")
+SPLIT_DIRECTION=${extrakto_window_split_direction:-$default_window_split_direction}
+
+default_window_lines=6
+extrakto_window_lines=$(tmux show-option -gqv "@extrakto_window_lines")
+WINDOW_LINES=${extrakto_window_lines:-$default_window_lines}
+
+
+tmux bind-key ${CLIP_KEY} split-window -${SPLIT_DIRECTION} -l ${WINDOW_LINES} "$CURRENT_DIR/tmux-extrakto -${CLIP_OPT} clip"
+tmux bind-key ${INSERT_KEY} split-window -${SPLIT_DIRECTION} -l ${WINDOW_LINES} "$CURRENT_DIR/tmux-extrakto -${INSERT_OPT} insert"

--- a/extrakto.tmux
+++ b/extrakto.tmux
@@ -2,10 +2,21 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-CLIP_KEY=$(tmux show-option -gqv "@extrakto_clip_key")
-CLIP_OPT=$(tmux show-option -gqv "@extrakto_clip_opt")
-INSERT_KEY=$(tmux show-option -gqv "@extrakto_insert_key")
-INSERT_OPT=$(tmux show-option -gqv "@extrakto_insert_opt")
 
-tmux bind-key ${CLIP_KEY:-e} split-window -v -l 6 "$CURRENT_DIR/tmux-extrakto -${CLIP_OPT:-wr} clip"
-tmux bind-key ${INSERT_KEY:-tab} split-window -v -l 6 "$CURRENT_DIR/tmux-extrakto -${INSERT_OPT:-wr} insert"
+default_clip_key="e"
+extrakto_clip_key=$(tmux show-option -gqv "@extrakto_clip_key")
+CLIP_KEY=${extrakto_clip_key:-$default_clip_key}
+
+default_clip_opt="wr"
+extrakto_clip_opt=$(tmux show-option -gqv "@extrakto_clip_opt")
+CLIP_OPT=${extrakto_clip_opt:-$default_clip_opt}
+
+default_insert_key="tab"
+extrakto_insert_key=$(tmux show-option -gqv "@extrakto_insert_key")
+INSERT_KEY=${extrakto_insert_key:-$default_insert_key}
+
+default_insert_opt="wr"
+extrakto_insert_opt=$(tmux show-option -gqv "@extrakto_insert_opt")
+INSERT_OPT=${extrakto_insert_opt:-$default_insert_opt}
+tmux bind-key ${CLIP_KEY} split-window -v -l 6 "$CURRENT_DIR/tmux-extrakto -${CLIP_OPT} clip"
+tmux bind-key ${INSERT_KEY} split-window -v -l 6 "$CURRENT_DIR/tmux-extrakto -${INSERT_OPT} insert"

--- a/extrakto.tmux
+++ b/extrakto.tmux
@@ -19,14 +19,14 @@ default_insert_opt="wr"
 extrakto_insert_opt=$(tmux show-option -gqv "@extrakto_insert_opt")
 INSERT_OPT=${extrakto_insert_opt:-$default_insert_opt}
 
-default_window_split_direction="v"
-extrakto_window_split_direction=$(tmux show-option -gqv "@extrakto_window_split_direction")
-SPLIT_DIRECTION=${extrakto_window_split_direction:-$default_window_split_direction}
+default_split_direction="v"
+extrakto_split_direction=$(tmux show-option -gqv "@extrakto_split_direction")
+SPLIT_DIRECTION=${extrakto_split_direction:-$default_split_direction}
 
-default_window_lines=6
-extrakto_window_lines=$(tmux show-option -gqv "@extrakto_window_lines")
-WINDOW_LINES=${extrakto_window_lines:-$default_window_lines}
+default_split_size=6
+extrakto_split_size=$(tmux show-option -gqv "@extrakto_split_size")
+SPLIT_SIZE=${extrakto_split_size:-$default_split_size}
 
 
-tmux bind-key ${CLIP_KEY} split-window -${SPLIT_DIRECTION} -l ${WINDOW_LINES} "$CURRENT_DIR/tmux-extrakto -${CLIP_OPT} clip"
-tmux bind-key ${INSERT_KEY} split-window -${SPLIT_DIRECTION} -l ${WINDOW_LINES} "$CURRENT_DIR/tmux-extrakto -${INSERT_OPT} insert"
+tmux bind-key ${CLIP_KEY} split-window -${SPLIT_DIRECTION} -l ${SPLIT_SIZE} "$CURRENT_DIR/tmux-extrakto -${CLIP_OPT} clip"
+tmux bind-key ${INSERT_KEY} split-window -${SPLIT_DIRECTION} -l ${SPLIT_SIZE} "$CURRENT_DIR/tmux-extrakto -${INSERT_OPT} insert"


### PR DESCRIPTION
Changes list:
* Group options together
* Make split direction and size configurable

I wanted to have more than the default 6 lines of height on the tmux window and I thought that it may be useful to have extrakto as a sidebar as well on some cases, so I went ahead and added configuration options.


This is how it looks with more height:
```
set -g @extrakto_window_split_direction 'v'
set -g @extrakto_window_lines "20"
```
![screenshot_20171001_150400](https://user-images.githubusercontent.com/806502/31057947-d0f787cc-a6c1-11e7-9f92-fe9758f8b634.png)


This is how it looks as an horizontal sidebar:

```
set -g @extrakto_window_split_direction 'h'
set -g @extrakto_window_lines "50"
```

![screenshot_20171001_150238](https://user-images.githubusercontent.com/806502/31057946-d0f77f8e-a6c1-11e7-944b-9e2525f92684.png)
