### PR TITLE
Use helper script to get tmux options

### DIFF
--- a/extrakto.tmux
+++ b/extrakto.tmux
@@ -2,31 +2,27 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+source "$CURRENT_DIR/scripts/helpers.sh"
+
 
 default_clip_key="e"
-extrakto_clip_key=$(tmux show-option -gqv "@extrakto_clip_key")
-CLIP_KEY=${extrakto_clip_key:-$default_clip_key}
+clip_key=$(get_tmux_option "@extrakto_clip_key" "$default_clip_key")
 
 default_clip_opt="wr"
-extrakto_clip_opt=$(tmux show-option -gqv "@extrakto_clip_opt")
-CLIP_OPT=${extrakto_clip_opt:-$default_clip_opt}
+clip_opt=$(get_tmux_option "@extrakto_clip_opt" "$default_clip_opt")
 
 default_insert_key="tab"
-extrakto_insert_key=$(tmux show-option -gqv "@extrakto_insert_key")
-INSERT_KEY=${extrakto_insert_key:-$default_insert_key}
+insert_key=$(get_tmux_option "@extrakto_insert_key" "$default_insert_key")
 
 default_insert_opt="wr"
-extrakto_insert_opt=$(tmux show-option -gqv "@extrakto_insert_opt")
-INSERT_OPT=${extrakto_insert_opt:-$default_insert_opt}
+insert_opt=$(get_tmux_option "@extrakto_insert_opt" "$default_insert_opt")
 
 default_split_direction="v"
-extrakto_split_direction=$(tmux show-option -gqv "@extrakto_split_direction")
-SPLIT_DIRECTION=${extrakto_split_direction:-$default_split_direction}
+split_direction=$(get_tmux_option "@extrakto_split_direction" "$default_split_direction")
 
 default_split_size=6
-extrakto_split_size=$(tmux show-option -gqv "@extrakto_split_size")
-SPLIT_SIZE=${extrakto_split_size:-$default_split_size}
+split_size=$(get_tmux_option "@extrakto_split_size" "$default_split_size")
 
 
-tmux bind-key ${CLIP_KEY} split-window -${SPLIT_DIRECTION} -l ${SPLIT_SIZE} "$CURRENT_DIR/tmux-extrakto -${CLIP_OPT} clip"
-tmux bind-key ${INSERT_KEY} split-window -${SPLIT_DIRECTION} -l ${SPLIT_SIZE} "$CURRENT_DIR/tmux-extrakto -${INSERT_OPT} insert"
+tmux bind-key ${clip_key} split-window -${split_direction} -l ${split_size} "$CURRENT_DIR/tmux-extrakto -${clip_opt} clip"
+tmux bind-key ${insert_key} split-window -${split_direction} -l ${split_size} "$CURRENT_DIR/tmux-extrakto -${insert_opt} insert"

--- a/extrakto.tmux
+++ b/extrakto.tmux
@@ -3,6 +3,7 @@
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "$CURRENT_DIR/scripts/helpers.sh"
+tmux_extrakto="$CURRENT_DIR/scripts/tmux-extrakto.sh"
 
 
 default_clip_key="e"
@@ -24,5 +25,5 @@ default_split_size=6
 split_size=$(get_tmux_option "@extrakto_split_size" "$default_split_size")
 
 
-tmux bind-key ${clip_key} split-window -${split_direction} -l ${split_size} "$CURRENT_DIR/tmux-extrakto -${clip_opt} clip"
-tmux bind-key ${insert_key} split-window -${split_direction} -l ${split_size} "$CURRENT_DIR/tmux-extrakto -${insert_opt} insert"
+tmux bind-key ${clip_key} split-window -${split_direction} -l ${split_size} "$tmux_extrakto -${clip_opt} clip"
+tmux bind-key ${insert_key} split-window -${split_direction} -l ${split_size} "$tmux_extrakto -${insert_opt} insert"

--- a/extrakto.tmux
+++ b/extrakto.tmux
@@ -6,23 +6,12 @@ source "$CURRENT_DIR/scripts/helpers.sh"
 tmux_extrakto="$CURRENT_DIR/scripts/tmux-extrakto.sh"
 
 
-default_clip_key="e"
-clip_key=$(get_tmux_option "@extrakto_clip_key" "$default_clip_key")
-
-default_clip_opt="wr"
-clip_opt=$(get_tmux_option "@extrakto_clip_opt" "$default_clip_opt")
-
-default_insert_key="tab"
-insert_key=$(get_tmux_option "@extrakto_insert_key" "$default_insert_key")
-
-default_insert_opt="wr"
-insert_opt=$(get_tmux_option "@extrakto_insert_opt" "$default_insert_opt")
-
-default_split_direction="v"
-split_direction=$(get_tmux_option "@extrakto_split_direction" "$default_split_direction")
-
-default_split_size=6
-split_size=$(get_tmux_option "@extrakto_split_size" "$default_split_size")
+clip_key=$(get_tmux_option "@extrakto_clip_key" "e")
+clip_opt=$(get_tmux_option "@extrakto_clip_opt" "wr")
+insert_key=$(get_tmux_option "@extrakto_insert_key" "tab")
+insert_opt=$(get_tmux_option "@extrakto_insert_opt" "wr")
+split_direction=$(get_tmux_option "@extrakto_split_direction" "v")
+split_size=$(get_tmux_option "@extrakto_split_size" "6")
 
 
 tmux bind-key ${clip_key} split-window -${split_direction} -l ${split_size} "$tmux_extrakto -${clip_opt} clip"

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,0 +1,11 @@
+get_tmux_option() {
+    local option=$1
+    local default_value=$2
+    local option_value=$(tmux show-option -gqv "$option")
+
+    if [ -z "$option_value" ]; then
+        echo "$default_value"
+    else
+        echo "$option_value"
+    fi
+}

--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-DIR="$(dirname "$(realpath "$0")")"
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+extrakto="$CURRENT_DIR/../extrakto.py"
 
 if [ -z "$2" ]; then
   echo "tmux-extrakto EXTRAKTO-OPT {clip|insert} [CLIP-TOOL]"
@@ -17,7 +18,7 @@ if [ -z "$CLIP" ]; then
 fi
 
 tmux set-buffer -- `tmux capture-pane -pJS -32768 -t ! | \
-  $DIR/extrakto.py $1 | \
+  $extrakto $1 | \
   fzf --bind=tab:accept`
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
This seems to be the prefered way of getting options' values on other
plugins like tmux-copycat and tmux-yank.

Examples:
https://github.com/tmux-plugins/tmux-yank/blob/master/scripts/helpers.sh#L34
https://github.com/tmux-plugins/tmux-copycat/blob/master/copycat.tmux#L11

Besides being similar to how other plugins do this, which eases contributors entrance, this results in more readable and shorter configs.