### PR TITLE
Make grab area configurable using an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ set -g @extrakto_default_opt 'w'
 set -g @extrakto_split_direction 'v'
 set -g @extrakto_split_size '7'
 set -g @extrakto_grab_area "full"
+set -g @extrakto_clip_tool ""
 ```
 - @extrakto_key: the key binding to start
 - @extrakto_default_opt: the default extract options
 - @extrakto_split_direction: whether the tmux split will be 'v'ertical or 'h'orizontal
 - @extrakto_split_size: the size of the tmux split
 - @extrakto_grab_area: whether you want extrakto to grab data from the "recent" area, or from "full" the pane. You can also set this option to any number you want, this allows you to grab a smaller amount of data from the pane than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto.
+- @extrakto_clip_tool: set this to whatever clipboard tool you would like Extrakto to use to copy data into your clipboard. By default this is not set but Extrakto has support for some OS clipboards.
 
 Available options for `extrakto_default_opt` are:
 - `w`  extract word tokens

--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ set -g @extrakto_default_opt 'w'
 set -g @extrakto_split_direction 'v'
 set -g @extrakto_split_size '7'
 set -g @extrakto_grab_area "full"
+set -g @extrakto_grab_size ""
 ```
 - @extrakto_key: the key binding to start
 - @extrakto_default_opt: the default extract options
 - @extrakto_split_direction: whether the tmux split will be 'v'ertical or 'h'orizontal
 - @extrakto_split_size: the size of the tmux split
 - @extrakto_grab_area: whether you want extrakto to grab data from the "recent" area, or from "full" the pane
+- @extrakto_grab_size: using this in combination with @extrakto_grab_area set to "full" allows you to grab a smaller amount of data from the pane than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto.
 
 Available options for `extrakto_default_opt` are:
 - `w`  extract word tokens

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ set -g @extrakto_key 'tab'
 set -g @extrakto_default_opt 'w'
 set -g @extrakto_split_direction 'v'
 set -g @extrakto_split_size '7'
-set -g @extrakto_grab_area "all"
+set -g @extrakto_grab_area "full"
 ```
 - @extrakto_key: the key binding to start
 - @extrakto_default_opt: the default extract options
 - @extrakto_split_direction: whether the tmux split will be 'v'ertical or 'h'orizontal
 - @extrakto_split_size: the size of the tmux split
-- @extrakto_grab_area: whether you want extrakto to grab data from the "visible" area, or from "all" the pane
+- @extrakto_grab_area: whether you want extrakto to grab data from the "recent" area, or from "full" the pane
 
 Available options for `extrakto_default_opt` are:
 - `w`  extract word tokens

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ set -g @extrakto_key 'tab'
 set -g @extrakto_default_opt 'w'
 set -g @extrakto_split_direction 'v'
 set -g @extrakto_split_size '7'
+set -g @extrakto_grab_area "all"
 ```
 - @extrakto_key: the key binding to start
 - @extrakto_default_opt: the default extract options
 - @extrakto_split_direction: whether the tmux split will be 'v'ertical or 'h'orizontal
 - @extrakto_split_size: the size of the tmux split
+- @extrakto_grab_area: whether you want extrakto to grab data from the "visible" area, or from "all" the pane
 
 Available options for `extrakto_default_opt` are:
 - `w`  extract word tokens

--- a/README.md
+++ b/README.md
@@ -45,14 +45,12 @@ set -g @extrakto_default_opt 'w'
 set -g @extrakto_split_direction 'v'
 set -g @extrakto_split_size '7'
 set -g @extrakto_grab_area "full"
-set -g @extrakto_grab_size ""
 ```
 - @extrakto_key: the key binding to start
 - @extrakto_default_opt: the default extract options
 - @extrakto_split_direction: whether the tmux split will be 'v'ertical or 'h'orizontal
 - @extrakto_split_size: the size of the tmux split
-- @extrakto_grab_area: whether you want extrakto to grab data from the "recent" area, or from "full" the pane
-- @extrakto_grab_size: using this in combination with @extrakto_grab_area set to "full" allows you to grab a smaller amount of data from the pane than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto.
+- @extrakto_grab_area: whether you want extrakto to grab data from the "recent" area, or from "full" the pane. You can also set this option to any number you want, this allows you to grab a smaller amount of data from the pane than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto.
 
 Available options for `extrakto_default_opt` are:
 - `w`  extract word tokens

--- a/extrakto.tmux
+++ b/extrakto.tmux
@@ -9,5 +9,6 @@ extrakto_key=$(get_tmux_option "@extrakto_key" "tab")
 default_opt=$(get_tmux_option "@extrakto_default_opt" "w")
 split_direction=$(get_tmux_option "@extrakto_split_direction" "v")
 split_size=$(get_tmux_option "@extrakto_split_size" "7")
+capture_pane_start=$(get_capture_pane_start)
 
-tmux bind-key ${extrakto_key} split-window -${split_direction} -l ${split_size} "$tmux_extrakto ${default_opt}"
+tmux bind-key ${extrakto_key} split-window -${split_direction} -l ${split_size} "$tmux_extrakto ${default_opt} ${capture_pane_start}"

--- a/extrakto.tmux
+++ b/extrakto.tmux
@@ -5,10 +5,8 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/scripts/helpers.sh"
 tmux_extrakto="$CURRENT_DIR/scripts/tmux-extrakto.sh"
 
-extrakto_key=$(get_tmux_option "@extrakto_key" "tab")
-default_opt=$(get_tmux_option "@extrakto_default_opt" "w")
-split_direction=$(get_tmux_option "@extrakto_split_direction" "v")
-split_size=$(get_tmux_option "@extrakto_split_size" "7")
-capture_pane_start=$(get_capture_pane_start)
+extrakto_key=$(get_option "@extrakto_key")
+split_direction=$(get_option "@extrakto_split_direction")
+split_size=$(get_option "@extrakto_split_size")
 
-tmux bind-key ${extrakto_key} split-window -${split_direction} -l ${split_size} "$tmux_extrakto ${default_opt} ${capture_pane_start}"
+tmux bind-key ${extrakto_key} split-window -${split_direction} -l ${split_size} "$tmux_extrakto"

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -11,24 +11,14 @@ get_tmux_option() {
 }
 
 get_capture_pane_start() {
-    split_direction=$(get_tmux_option "@extrakto_split_direction" "v")
-    split_size=$(get_tmux_option "@extrakto_split_size" "7")
     grab_area=$(get_tmux_option "@extrakto_grab_area" "full")
 
-    capture_start="-32768"
+    history_limit=$(get_tmux_option 'history-limit' '2000')
+    capture_start="-${history_limit}"
 
     if [ "$grab_area" == "recent" ]; then
-        if [ "$split_direction" == "v" ]; then
-            capture_start=-"$split_size"
-        else
-            # NOTE: having an horizontal split you may end up shifting some
-            # visible lines upwards. I can't think of a reliable way of
-            # calculating how many extra lines we should add to compensate that
-            # movement. This will vary on how long are the lines you're seeing
-            # by the time you open extrakto.
-            # This value may need to be tweaked to be a better default.
-            capture_start="0"
-        fi
+        # TODO: check that this is good enough for "recent"
+        capture_start="-10"
     fi
 
     echo $capture_start

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -30,9 +30,6 @@ get_option() {
 
         "@extrakto_grab_area")
             echo $(get_tmux_option $option "full") ;;
-
-        "@extrakto_grab_size")
-            echo $(get_tmux_option $option "") ;;
     esac
 }
 
@@ -49,20 +46,15 @@ get_capture_pane_start() {
         # TODO: check that this is good enough for "recent"
         local capture_start="-10"
 
-        echo $capture_start
-        return
-    fi
-
-    local grab_size=$(get_tmux_option "@extrakto_grab_size")
-
-    if [[ -n "$grab_size" ]]; then
-        # use the user defined limit for how much to grab
-        local capture_start="-${grab_size}"
-    else
-        # otherwise use the history limit, this is all the data on the pane
+    elif [ "$grab_area" == "full" ]; then
+        # use the history limit, this is all the data on the pane
         # if not set just go with tmux's default
         local history_limit=$(get_tmux_option "history-limit" "2000")
         local capture_start="-${history_limit}"
+
+    else
+        # use the user defined limit for how much to grab
+        local capture_start="-${grab_area}"
     fi
 
     echo $capture_start

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 get_tmux_option() {
     local option=$1
     local default_value=$2
@@ -10,15 +12,57 @@ get_tmux_option() {
     fi
 }
 
-get_capture_pane_start() {
-    grab_area=$(get_tmux_option "@extrakto_grab_area" "full")
+get_option() {
+    local option=$1
 
-    history_limit=$(get_tmux_option 'history-limit' '2000')
-    capture_start="-${history_limit}"
+    case $option in
+        "@extrakto_key")
+            echo $(get_tmux_option $option "tab") ;;
+
+        "@extrakto_default_opt")
+            echo $(get_tmux_option $option "w") ;;
+
+        "@extrakto_split_direction")
+            echo $(get_tmux_option $option "v") ;;
+
+        "@extrakto_split_size")
+            echo $(get_tmux_option $option "7") ;;
+
+        "@extrakto_grab_area")
+            echo $(get_tmux_option $option "full") ;;
+
+        "@extrakto_grab_size")
+            echo $(get_tmux_option $option "") ;;
+    esac
+}
+
+# This returns the start point parameter for `tmux capture-pane`.
+# The result will depend on how the user has set the grab area and grab size.
+#
+# If you pass a parameter to this function, it will be used to overwrite the
+# user's grab area configuration.
+get_capture_pane_start() {
+    local grab_area=$(get_option "@extrakto_grab_area")
+    grab_area=${1:-$grab_area}  # overwrite with $1, if set.
 
     if [ "$grab_area" == "recent" ]; then
         # TODO: check that this is good enough for "recent"
-        capture_start="-10"
+        local capture_start="-10"
+
+        echo $capture_start
+        return
+    fi
+
+    local grab_size=$(get_tmux_option "@extrakto_grab_size")
+
+    if [[ -n "$grab_size" ]]; then
+        # use the user defined limit for how much to grab
+        local capture_start="-${grab_size}"
+    else
+        # otherwise use the history limit, this is all the data on the pane
+        # if not set just go with tmux's default
+        local history_limit=$(get_tmux_option "history-limit" "2000")
+        local capture_start="-${history_limit}"
     fi
 
     echo $capture_start

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -13,11 +13,11 @@ get_tmux_option() {
 get_capture_pane_start() {
     split_direction=$(get_tmux_option "@extrakto_split_direction" "v")
     split_size=$(get_tmux_option "@extrakto_split_size" "7")
-    grab_area=$(get_tmux_option "@extrakto_grab_area" "all")
+    grab_area=$(get_tmux_option "@extrakto_grab_area" "full")
 
     capture_start="-32768"
 
-    if [ "$grab_area" == "visible" ]; then
+    if [ "$grab_area" == "recent" ]; then
         if [ "$split_direction" == "v" ]; then
             capture_start=-"$split_size"
         else

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -30,6 +30,9 @@ get_option() {
 
         "@extrakto_grab_area")
             echo $(get_tmux_option $option "full") ;;
+
+        "@extrakto_clip_tool")
+            echo $(get_tmux_option $option "") ;;
     esac
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -9,3 +9,27 @@ get_tmux_option() {
         echo "$option_value"
     fi
 }
+
+get_capture_pane_start() {
+    split_direction=$(get_tmux_option "@extrakto_split_direction" "v")
+    split_size=$(get_tmux_option "@extrakto_split_size" "7")
+    grab_area=$(get_tmux_option "@extrakto_grab_area" "all")
+
+    capture_start="-32768"
+
+    if [ "$grab_area" == "visible" ]; then
+        if [ "$split_direction" == "v" ]; then
+            capture_start=-"$split_size"
+        else
+            # NOTE: having an horizontal split you may end up shifting some
+            # visible lines upwards. I can't think of a reliable way of
+            # calculating how many extra lines we should add to compensate that
+            # movement. This will vary on how long are the lines you're seeing
+            # by the time you open extrakto.
+            # This value may need to be tweaked to be a better default.
+            capture_start="0"
+        fi
+    fi
+
+    echo $capture_start
+}

--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$CURRENT_DIR/helpers.sh"
 extrakto="$CURRENT_DIR/../extrakto.py"
 
 if [ -z "$1" ]; then
@@ -18,9 +19,11 @@ if [ -z "$CLIP" ]; then
   esac
 fi
 
+capture_pane_start=`get_capture_pane_start`
+
 function capture() {
 
-  sel=$(tmux capture-pane -pJS -32768 -t ! | \
+  sel=$(tmux capture-pane -pJS ${capture_pane_start} -t ! | \
     $extrakto -r$EXTRAKTO_OPT | \
     fzf \
       --header="tab=insert, enter=copy, ctrl-f=toggle filter [$EXTRAKTO_OPT]" \

--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -4,11 +4,6 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 extrakto="$CURRENT_DIR/../extrakto.py"
 
-if [ -z "$1" ]; then
-  echo "tmux-extrakto EXTRAKTO-OPT [CLIP-TOOL]"
-  exit 1
-fi
-
 # We are not passing this parameter. TODO: configure as option?
 # CLIP=$2
 CLIP=""

--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -6,7 +6,7 @@ extrakto="$CURRENT_DIR/../extrakto.py"
 
 # We are not passing this parameter. TODO: configure as option?
 # CLIP=$2
-CLIP=""
+CLIP=$(get_option "@extrakto_clip_tool")
 if [ -z "$CLIP" ]; then
   case "`uname`" in
     'Linux') CLIP='xclip -i -selection clipboard >/dev/null' ;;

--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -16,6 +16,8 @@ if [ -z "$CLIP" ]; then
 fi
 
 grab_area=$(get_option "@extrakto_grab_area")
+original_grab_area=${grab_area}  # keep this so we can cycle between alternatives on fzf
+
 capture_pane_start=$(get_capture_pane_start)
 EXTRAKTO_OPT=$(get_option "@extrakto_default_opt")
 
@@ -48,12 +50,22 @@ function capture() {
       capture
       ;;
     ctrl-l)
-      if [[ $grab_area == 'full' ]]; then
-        grab_area="recent"
+
+      # cycle between options like this: recent -> full -> custom (if any)-> recent ...
+      if [[ $grab_area == "recent" ]]; then
+          grab_area="full"
+      elif [[ $grab_area == "full" ]]; then
+          grab_area="recent"
+
+          if [[ "$original_grab_area" != "recent" && "$original_grab_area" != "full" ]]; then
+              grab_area="$original_grab_area"
+          fi
       else
-        grab_area="full"
+          grab_area="recent"
       fi
+
       capture_pane_start=$(get_capture_pane_start "$grab_area")
+
       capture
       ;;
   esac

--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "$CURRENT_DIR/helpers.sh"
 extrakto="$CURRENT_DIR/../extrakto.py"
 
 if [ -z "$1" ]; then
@@ -10,7 +9,10 @@ if [ -z "$1" ]; then
 fi
 
 EXTRAKTO_OPT=$1
-CLIP=$2
+capture_pane_start=$2
+
+# CLIP=$2  # we are not passing this parameter
+CLIP=""
 if [ -z "$CLIP" ]; then
   case "`uname`" in
     'Linux') CLIP='xclip -i -selection clipboard >/dev/null' ;;
@@ -18,8 +20,6 @@ if [ -z "$CLIP" ]; then
     *) ;;
   esac
 fi
-
-capture_pane_start=`get_capture_pane_start`
 
 function capture() {
 


### PR DESCRIPTION
So, this should tackle the proposed new option on #8.

Here are some thoughts about this implementation:
* We now have "default" values for options in two files: `extrakto.tmux` and `helpers.sh`
* When you use an horizontal extrakto you may end up shifting some lines upwards but I can't think of a reliable way of calculating how many extra lines we should add for that. This will vary on how long are the lines you're seeing by the time you open extrakto.
* Available configuration now can't be found in "just one file" as I liked to think before. This doesn't need to be a bad thing, it's just a nice thing we had before and now we don't. If we do want to have that we may need to think of a better way of managing configurations.

@maximbaz since you are our test user for this feature let me know how it feels. I've tested it trying to grab lines right on the edge of the visible screen and not grabing lines right on the edge of the non-visible screen and it seems to be working fine.