### PR TITLE
Match hidden files correctly in words mode

### DIFF
--- a/extrakto.py
+++ b/extrakto.py
@@ -77,7 +77,7 @@ def get_words(text, ml):
     words = []
 
     for m in re.finditer(RE_WORD, "\n" + text):
-        item = m.group().strip(',.:;()[]{}<>\'"')
+        item = m.group().strip(',:;()[]{}<>\'"').rstrip('.')
         if len(item) > ml:
             words.append(item)
 

--- a/tests/test_get_words.py
+++ b/tests/test_get_words.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from extrakto import get_words
+
+
+class TestGetWords(unittest.TestCase):
+    def test_skip_dot_last_word_in_sentence(self):
+        text = "Hello world. Extrakto is an awesome plugin."
+        words = [
+            "Hello", "world", "Extrakto", "awesome", "plugin"
+        ]
+
+        result = get_words(text, 4)
+        self.assertEquals(words, result)
+
+    def test_match_hidden_files(self):
+        text = "one /home/user/.hidden.txt two .hidden.txt three ./.hidden.txt four ../.hidden.txt"
+        words = [
+            "/home/user/.hidden.txt", ".hidden.txt", "./.hidden.txt",
+            "../.hidden.txt"
+        ]
+
+        result = get_words(text, 6)
+        self.assertEquals(words, result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Stripping `.` from both sides of a word does not handle hidden files, as I show in the test for hidden files. 
The correct way would be to only strip it from the end of the string, which is shown in the other test.

