### PR TITLE
Use table to show options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,25 +43,31 @@ You should now have all `extrakto` key bindings defined.
 
 ### Options
 
+To set any of these options write on your `~/.tmux.conf` file:
+
 ```
-# Note: these are the default options
-set -g @extrakto_key 'tab'
-set -g @extrakto_default_opt 'word'
-set -g @extrakto_split_direction 'v'
-set -g @extrakto_split_size '7'
-set -g @extrakto_grab_area 'full'
-set -g @extrakto_clip_tool ''
-set -g @extrakto_fzf_tool 'fzf'
-set -g @extrakto_open_tool 'auto'
+set -g <option> "<value>"
 ```
-- @extrakto_key: the key binding to start
-- @extrakto_default_opt: the default extract options (`word` or `path/url`)
-- @extrakto_split_direction: whether the tmux split will be 'v'ertical or 'h'orizontal
-- @extrakto_split_size: the size of the tmux split
-- @extrakto_grab_area: whether you want extrakto to grab data from the `recent` area, or from `full` the pane. You can also set this option to any number you want, this allows you to grab a smaller amount of data from the pane than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto.
-- @extrakto_clip_tool: set this to whatever clipboard tool you would like extrakto to use to copy data into your clipboard. By default this is not set but extrakto has support for some OS clipboards.
-- @extrakto_fzf_tool: set this to path of fzf if it can't be found in your `PATH`.
-- @extrakto_open_tool: set this to path of your own tool or `auto` to use your platforms *open* implementation.
+
+Where `<option>` and `<value>` are one of the specified here:
+
+| Option                    | Default | Description |
+| :---                      | :---:   | :--- |
+| `@extrakto_key`             | `tab`   | The key binding to start |
+| `@extrakto_default_opt`     | `word`  | The default extract options (`word` or `path/url`) |
+| `@extrakto_split_direction` | `v`     | Whether the tmux split will be `v`ertical or `h`orizontal |
+| `@extrakto_split_size`      | `7`     | The size of the tmux split |
+| `@extrakto_grab_area`       | `full`  | Whether you want extrakto to grab data from the `recent` area, or from `full` the pane. You can also set this option to any number you want, this allows you to grab a smaller amount of data from the pane than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto. |
+| `@extrakto_clip_tool`       |         | Set this to whatever clipboard tool you would like extrakto to use to copy data into your clipboard. By default this is not set but extrakto has support for some OS clipboards. |
+| `@extrakto_fzf_tool`        | `fzf`   | Set this to path of fzf if it can't be found in your `PATH`. |
+| `@extrakto_open_tool`       | `auto`  | Set this to path of your own tool or `auto` to use your platforms *open* implementation. |
+
+
+Example:
+
+```
+set -g @extrakto_split_size "15"
+```
 
 ## CLI
 


### PR DESCRIPTION
Here's an idea on how to show options differently.
Visually it takes a more space but I think that it is easier to read.

Current options:
![screenshot_20171021_172012](https://user-images.githubusercontent.com/806502/31855571-33e5d574-b684-11e7-8a13-7990dfe390d6.png)

Proposed options:
![screenshot_20171021_171951](https://user-images.githubusercontent.com/806502/31855570-33c402aa-b684-11e7-9921-bbb9cf55ddd3.png)

Thoughts?