### PR TITLE
Added `Ctrl-S` to search for selected text

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ You can **fuzzy find your text** instead of selecting it by hand:
   - `enter` to copy it to the clipboard,
   - `ctrl-o` to open the path/url or
   - `ctrl-e` to edit with `$EDITOR`
+  - `ctrl-s` to search for it
 
 Use it for paths, URLs, options from a man page, git hashes, docker container names, ...
 

--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -48,6 +48,7 @@ function capture() {
   header="tab=insert, enter=copy"
   if [ -n "$open_tool" ]; then header="$header, ctrl-o=open"; fi
   header="$header, ctrl-e=edit"
+  header="$header, ctrl-s=search"
   header="$header, ctrl-f=toggle filter [$extrakto_opt], ctrl-l=grab area [$grab_area]"
 
   case $extrakto_opt in
@@ -62,7 +63,7 @@ function capture() {
     $extrakto -r$extrakto_flags | \
     $fzf_tool \
       --header="$header" \
-      --expect=tab,enter,ctrl-e,ctrl-f,ctrl-l,ctrl-o,esc \
+      --expect=tab,enter,ctrl-e,ctrl-s,ctrl-f,ctrl-l,ctrl-o,esc \
       --tiebreak=index)
 
   if [ $? -gt 0 ]; then
@@ -95,6 +96,10 @@ function capture() {
         extrakto_opt='word'
       fi
       capture
+      ;;
+
+    ctrl-s)
+      tmux copy-mode -t ! \; send-keys -t ! -X search-backward "$text"
       ;;
 
     ctrl-l)


### PR DESCRIPTION
With this feature *extrakto* can be used to search for a first word of sentence (for example a commit message) and to quickly select the rest of this sentence in copy-mode afterwards.