### PR TITLE
Line extraktion feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 You can **fuzzy find your text** instead of selecting it by hand:
 
 - press tmux `prefix + tab` to start extrakto
-- fuzzy find the text/path/url
+- fuzzy find the text/path/url/line
 - press
   - `tab` to insert it to the current pane,
   - `enter` to copy it to the clipboard,
@@ -61,7 +61,7 @@ Where `<option>` and `<value>` are one of the specified here:
 | Option                    | Default | Description |
 | :---                      | :---:   | :--- |
 | `@extrakto_key`             | `tab`   | The key binding to start. If you have any special requirements (like a custom key table) set this to '' and define a binding in your `.tmux.conf`. See `extrakto.tmux` for a sample. |
-| `@extrakto_default_opt`     | `word`  | The default extract options (`word` or `path/url`) |
+| `@extrakto_default_opt`     | `word`  | The default extract options (`word`, `lines` or `path/url`) |
 | `@extrakto_split_direction` | `v`     | Whether the tmux split will be `v`ertical or `h`orizontal |
 | `@extrakto_split_size`      | `7`     | The size of the tmux split |
 | `@extrakto_grab_area`       | `full`  | Whether you want extrakto to grab data from the `recent` area, or from `full` the pane. You can also set this option to any number you want, this allows you to grab a smaller amount of data from the pane than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto. |
@@ -98,7 +98,7 @@ Requires Python 2/3.
 ### CLI Usage
 
 ```
-usage: extrakto.py [-h] [-p] [-u] [-w] [-r] [-m MIN_LENGTH]
+usage: extrakto.py [-h] [-p] [-u] [-w] [-l] [-r] [-m MIN_LENGTH]
 
 Extracts tokens from plaintext.
 
@@ -107,6 +107,7 @@ optional arguments:
   -p, --paths           extract path tokens
   -u, --urls            extract url tokens
   -w, --words           extract word tokens
+  -l, --lines           extract lines
   -r, --reverse         reverse output
   -m MIN_LENGTH, --min-length MIN_LENGTH
                         minimum token length

--- a/extrakto.py
+++ b/extrakto.py
@@ -45,6 +45,9 @@ def get_args():
     parser.add_argument('-w', '--words', action='store_true',
                         help='extract "word" tokens')
 
+    parser.add_argument('-l', '--lines', action='store_true',
+                        help='extract "line" tokens')
+
     parser.add_argument('-r', '--reverse', action='store_true',
                         help='reverse output')
 
@@ -96,6 +99,15 @@ def get_words(text, min_length):
     return words
 
 
+def get_lines(text, min_length):
+    lines = []
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if len(line) >= min_length:
+            lines.append(line)
+
+    return lines
 
 
 def main():
@@ -127,6 +139,9 @@ def main():
 
     elif args.urls:
         res = get_urls(get_input(), args.min_length)
+
+    elif args.lines:
+        res = get_lines(get_input(), args.min_length)
 
     else:
         print('unknown option, see --help')

--- a/extrakto.py
+++ b/extrakto.py
@@ -46,7 +46,7 @@ def get_args():
                         help='extract "word" tokens')
 
     parser.add_argument('-l', '--lines', action='store_true',
-                        help='extract "line" tokens')
+                        help='extract lines')
 
     parser.add_argument('-r', '--reverse', action='store_true',
                         help='reverse output')

--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -52,6 +52,7 @@ function capture() {
 
   case $extrakto_opt in
     'path/url') extrakto_flags='pu' ;;
+    'lines') extrakto_flags='l' ;;
     *) extrakto_flags='w' ;;
   esac
 
@@ -91,6 +92,8 @@ function capture() {
     ctrl-f)
       if [[ $extrakto_opt == 'word' ]]; then
         extrakto_opt='path/url'
+      elif [[ $extrakto_opt == 'path/url' ]]; then
+        extrakto_opt='lines'
       else
         extrakto_opt='word'
       fi

--- a/tests/test_get_lines.py
+++ b/tests/test_get_lines.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from extrakto import get_lines
+
+
+class TestGetLines(unittest.TestCase):
+
+    def test_get_lines_of_min_length(self):
+        text = """\
+first line
+   second line with whitespace
+short"""
+        words = [
+            "first line", "second line with whitespace",
+        ]
+
+        result = get_lines(text, 6)
+        self.assertEquals(words, result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I find it handy to copy entire lines of the screen (e.g. to copy an error message to the clipboard). Hence I wrote a small expansion.

Code changes
---

- add `get_lines()` function in `extracto.py`. Splits input text at newlines and strips whitespace.
- add command line option (`-l`, `--lines`), update tmux plugin accordingly (ctrl-f now cycles through three options)