### PR TITLE
multi pane fuzzy completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Where `<option>` and `<value>` are one of the specified here:
 | `@extrakto_default_opt`     | `word`  | The default extract options (`word`, `lines` or `path/url`) |
 | `@extrakto_split_direction` | `v`     | Whether the tmux split will be `v`ertical or `h`orizontal |
 | `@extrakto_split_size`      | `7`     | The size of the tmux split |
-| `@extrakto_grab_area`       | `full`  | Whether you want extrakto to grab data from the `recent` area, or from `full` the pane. You can also set this option to any number you want, this allows you to grab a smaller amount of data from the pane than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto. |
+| `@extrakto_grab_area`       | `full`  | Whether you want extrakto to grab data from the `recent` area, the `full` pane, all current window's `recent` areas or all current window's `full` panes. You can also set this option to any number you want (or number preceded by "window ", e.g. "window 500"), this allows you to grab a smaller amount of data from the pane(s) than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto. |
 | `@extrakto_clip_tool`       | `auto`  | Set this to whatever clipboard tool you would like extrakto to use to copy data into your clipboard. `auto` will try to choose the correct clipboard for your platform. |
 | `@extrakto_fzf_tool`        | `fzf`   | Set this to path of fzf if it can't be found in your `PATH`. |
 | `@extrakto_open_tool`       | `auto`  | Set this to path of your own tool or `auto` to use your platforms *open* implementation. |

--- a/extrakto.tmux
+++ b/extrakto.tmux
@@ -10,5 +10,5 @@ split_direction=$(get_option "@extrakto_split_direction")
 split_size=$(get_option "@extrakto_split_size")
 
 if [ -n "${extrakto_key}" ]; then
-  tmux bind-key ${extrakto_key} split-window -c "#{pane_current_path}" -${split_direction} -l ${split_size} "$tmux_extrakto"
+  tmux bind-key ${extrakto_key} run-shell "tmux split-window -c \"#{pane_current_path}\" -${split_direction} -l ${split_size} \"$tmux_extrakto #{pane_id}\""
 fi

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -47,17 +47,21 @@ get_option() {
 get_capture_pane_start() {
     local grab_area=$1
 
-    if [ "$grab_area" == "recent" ]; then
+    if [[ "$grab_area" == "recent" || "$grab_area" == "window recent" ]]; then
         local capture_start="-10"
 
-    elif [ "$grab_area" == "full" ]; then
+    elif [[ "$grab_area" == "full" || "$grab_area" == "window full" ]]; then
         # use the history limit, this is all the data on the pane
         # if not set just go with tmux's default
         local history_limit=$(get_tmux_option "history-limit" "2000")
         local capture_start="-${history_limit}"
 
+    elif [[ "$grab_area" =~ ^window\  ]]; then
+        # use the user defined limit for how much to grab from every pane in the current window
+        local capture_start="-${grab_area:7}"
+
     else
-        # use the user defined limit for how much to grab
+        # use the user defined limit for how much to grab from the current pane
         local capture_start="-${grab_area}"
     fi
 


### PR DESCRIPTION
Sometimes I'm with a split of vim and a console. If editing in the vim pane, extrakto doesn't fuzzy find text/paths in the console pane. It would be great if it could do so. Meanwhile I have to select the target console pane, fuzzyfind there and copy, then get to the vim pane and paste.