### PR TITLE
Give a config tip about clipboard-less use case in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ set -g @extrakto_split_size "15"
 set -g @extrakto_clip_tool "xsel --input --clipboard" # works better for nvim
 ```
 
+If you want Enter to paste to tmux the same way Tab does, you can set `@extrakto_clip_tool` to `tmux paste-buffer`:
+
+```
+set -g @extrakto_clip_tool "tmux paste-buffer"
+```
+
 ---
 
 # CLI


### PR DESCRIPTION
I use tmux almost exclusively on remote servers. The remote servers rarely have a display running, so `xsel`/`xclip` error out. Often, I also don't _want_ to share a clipboard with the tmux session.

My primary use case for extrakto is re-pasting some text into the current command prompt. My muscle memory for fzf makes me hit Enter as often as not, which results in an error instead of a pasted command. I'd prefer Enter to do something useful.

I just spent half an hour figuring out how to do that - remap the "Enter" action? disable clipboard? pray to the forgotten gods? - until I had the embarrassing realization that I could just set the clipboard action to `tmux paste-buffer`.

I recognize that clipboard-less use might go against extrakto's raison d'être, but I think this is a neat option to provide - and since you already provide it, it might as well be documented.