### PR TITLE
Special-case for Termux to avoid errors and support system clipboard

### DIFF
--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -18,7 +18,9 @@ original_grab_area=${grab_area}  # keep this so we can cycle between alternative
 if [[ "$clip_tool" == "auto" ]]; then
   case "`uname`" in
     'Linux')
-      if [[ $(cat /proc/sys/kernel/osrelease) =~ 'Microsoft' ]]; then
+      if [[ $PREFIX == *"com.termux"* ]]; then
+        clip_tool='termux-clipboard-set'
+      elif [[ $(cat /proc/sys/kernel/osrelease) =~ 'Microsoft' ]]; then
         clip_tool='clip.exe'
       else
         clip_tool='xclip -i -selection clipboard >/dev/null'


### PR DESCRIPTION
Termux has special utilities for doing system clipboard work, so this adds support for that.

Also, termux doesn't have a /proc folder (it uses a $PREFIX) so without this change, hitting ENTER from extrakto will give an error for the invalid path, on top of the error for missing xclip.