### PR TITLE
Enable copying to terminals supporting the OSC-52 escape sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Where `<option>` and `<value>` are one of the specified here:
 | `@extrakto_split_size`      | `7`     | The size of the tmux split |
 | `@extrakto_grab_area`       | `full`  | Whether you want extrakto to grab data from the `recent` area, the `full` pane, all current window's `recent` areas or all current window's `full` panes. You can also set this option to any number you want (or number preceded by "window ", e.g. "window 500"), this allows you to grab a smaller amount of data from the pane(s) than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto. |
 | `@extrakto_clip_tool`       | `auto`  | Set this to whatever clipboard tool you would like extrakto to use to copy data into your clipboard. `auto` will try to choose the correct clipboard for your platform. |
+| `@extrakto_clip_tool_run`   | `bg`    | Set this to `fg` to have your clipboard tool run in a foreground shell (enabling copying to clipboard using OSC52). |
 | `@extrakto_fzf_tool`        | `fzf`   | Set this to path of fzf if it can't be found in your `PATH`. |
 | `@extrakto_open_tool`       | `auto`  | Set this to path of your own tool or `auto` to use your platforms *open* implementation. |
 | `@extrakto_copy_key`        | `enter` | Key to copy selection to clipboard. |
 | `@extrakto_insert_key`      | `tab`   | Key to insert selection. |
-| `@extrakto_fg_copy`         | `1`     | Invoke open\_tool in a foreground shell (enables copying to clipboard using OSC52). |
 
 
 Example:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Where `<option>` and `<value>` are one of the specified here:
 | `@extrakto_open_tool`       | `auto`  | Set this to path of your own tool or `auto` to use your platforms *open* implementation. |
 | `@extrakto_copy_key`        | `enter` | Key to copy selection to clipboard. |
 | `@extrakto_insert_key`      | `tab`   | Key to insert selection. |
+| `@extrakto_fg_copy`         | `1`     | Invoke open\_tool in a foreground shell (enables copying to clipboard using OSC52). |
 
 
 Example:

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -45,6 +45,9 @@ get_option() {
 
         "@extrakto_insert_key")
             echo $(get_tmux_option $option "tab") ;;
+
+        "@extrakto_fg_copy")
+            echo $(get_tmux_option $option "") ;;
     esac
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -46,8 +46,8 @@ get_option() {
         "@extrakto_insert_key")
             echo $(get_tmux_option $option "tab") ;;
 
-        "@extrakto_fg_copy")
-            echo $(get_tmux_option $option "") ;;
+        "@extrakto_clip_tool_run")
+            echo $(get_tmux_option $option "bg") ;;
     esac
 }
 

--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -13,6 +13,7 @@ fzf_tool=$(get_option "@extrakto_fzf_tool")
 open_tool=$(get_option "@extrakto_open_tool")
 copy_key=$(get_option "@extrakto_copy_key")
 insert_key=$(get_option "@extrakto_insert_key")
+fg_copy=$(get_option "@extrakto_fg_copy")
 
 capture_pane_start=$(get_capture_pane_start "$grab_area")
 original_grab_area=${grab_area}  # keep this so we can cycle between alternatives on fzf
@@ -99,8 +100,13 @@ function capture() {
 
     ${copy_key})
       tmux set-buffer -- "$text"
-      # run in background as xclip won't work otherwise
-      tmux run-shell -b "tmux show-buffer|$clip_tool"
+      if [[ "$fg_copy" == "1" ]]; then
+        # run in foreground as OSC-52 copying won't work otherwise
+        tmux run-shell "tmux show-buffer|$clip_tool"
+      else
+        # run in background as xclip won't work otherwise
+        tmux run-shell -b "tmux show-buffer|$clip_tool"
+      fi
       ;;
 
     ${insert_key})

--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -9,11 +9,11 @@ extrakto="$CURRENT_DIR/../extrakto.py"
 grab_area=$(get_option "@extrakto_grab_area")
 extrakto_opt=$(get_option "@extrakto_default_opt")
 clip_tool=$(get_option "@extrakto_clip_tool")
+clip_tool_run=$(get_option "@extrakto_clip_tool_run")
 fzf_tool=$(get_option "@extrakto_fzf_tool")
 open_tool=$(get_option "@extrakto_open_tool")
 copy_key=$(get_option "@extrakto_copy_key")
 insert_key=$(get_option "@extrakto_insert_key")
-fg_copy=$(get_option "@extrakto_fg_copy")
 
 capture_pane_start=$(get_capture_pane_start "$grab_area")
 original_grab_area=${grab_area}  # keep this so we can cycle between alternatives on fzf
@@ -100,7 +100,7 @@ function capture() {
 
     ${copy_key})
       tmux set-buffer -- "$text"
-      if [[ "$fg_copy" == "1" ]]; then
+      if [[ "$clip_tool_run" == "fg" ]]; then
         # run in foreground as OSC-52 copying won't work otherwise
         tmux run-shell "tmux show-buffer|$clip_tool"
       else


### PR DESCRIPTION
Added a fg_copy option. When fg_copy is set, $clip_tool runs in the foreground.

[More details about OSC 52](https://sunaku.github.io/tmux-yank-osc52.html).