### PR TITLE
cleanup & preserve fzf query between ctrl+{f,g}

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 get_tmux_option() {
-    local option=$1
-    local default_value=$2
-    local option_value=$(tmux show-option -gqv "$option")
+    local option default_value option_value
 
-    if [ -z "$option_value" ]; then
+    option=$1
+    default_value=$2
+    option_value=$(tmux show-option -gqv "$option")
+
+    if [[ -z "$option_value" ]]; then
         echo "$default_value"
     else
         echo "$option_value"
@@ -15,7 +17,7 @@ get_tmux_option() {
 get_option() {
     local option=$1
 
-    case $option in
+    case "$option" in
         "@extrakto_key")
             echo $(get_tmux_option $option "tab")
             ;;
@@ -65,25 +67,27 @@ get_option() {
 # This returns the start point parameter for `tmux capture-pane`.
 # The result will depend on how the user has set the grab area and grab size.
 get_capture_pane_start() {
-    local grab_area=$1
+    local grab_area capture_start history_limit
+
+    grab_area="$1"
 
     if [[ "$grab_area" == "recent" || "$grab_area" == "window recent" ]]; then
-        local capture_start="-10"
+        capture_start="-10"
 
     elif [[ "$grab_area" == "full" || "$grab_area" == "window full" ]]; then
         # use the history limit, this is all the data on the pane
         # if not set just go with tmux's default
-        local history_limit=$(get_tmux_option "history-limit" "2000")
-        local capture_start="-${history_limit}"
+        history_limit=$(get_tmux_option "history-limit" "2000")
+        capture_start="-${history_limit}"
 
     elif [[ "$grab_area" =~ ^window\  ]]; then
         # use the user defined limit for how much to grab from every pane in the current window
-        local capture_start="-${grab_area:7}"
+        capture_start="-${grab_area:7}"
 
     else
         # use the user defined limit for how much to grab from the current pane
-        local capture_start="-${grab_area}"
+        capture_start="-${grab_area}"
     fi
 
-    echo $capture_start
+    echo "$capture_start"
 }

--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -20,18 +20,22 @@ CAPTURE_PANE_START=$(get_capture_pane_start "$GRAB_AREA")
 ORIGINAL_GRAB_AREA=${GRAB_AREA} # keep this so we can cycle between alternatives on fzf
 
 
+# note we use the superfluous 'local' keyword in front of 'captured' var;
+# without it we get intermittent issues with extracto python script (when reading stdin);
+# likely caused by some odd unicode-character encoding problem; debug by   echo "$captured" >> /tmp/capture
 capture_panes() {
     local pane captured
 
     if [[ $GRAB_AREA =~ ^window\  ]]; then
         for pane in $(tmux list-panes -F "#{pane_active}:#{pane_id}"); do
             if [[ $pane =~ ^0: && ${pane:2} != ${LAST_ACTIVE_PANE} ]]; then
-                captured+=$(tmux capture-pane -pJS ${CAPTURE_PANE_START} -t ${pane:2})
+                local captured+="$(tmux capture-pane -pJS ${CAPTURE_PANE_START} -t ${pane:2})"
                 captured+=$'\n'
             fi
         done
     fi
-    captured+=$(tmux capture-pane -pJS ${CAPTURE_PANE_START} -t !)
+
+    local captured+="$(tmux capture-pane -pJS ${CAPTURE_PANE_START} -t !)"  # note the superfluous 'local' for some reason fixes the encoding problem
 
     echo "$captured"
 }

--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -1,74 +1,77 @@
 #!/bin/bash
 
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CURRENT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LAST_ACTIVE_PANE=$1
 source "$CURRENT_DIR/helpers.sh"
-extrakto="$CURRENT_DIR/../extrakto.py"
+EXTRAKTO="$CURRENT_DIR/../extrakto.py"
+PLATFORM="$(uname)"
 
-# options
-grab_area=$(get_option "@extrakto_grab_area")
-extrakto_opt=$(get_option "@extrakto_default_opt")
-clip_tool=$(get_option "@extrakto_clip_tool")
-clip_tool_run=$(get_option "@extrakto_clip_tool_run")
-fzf_tool=$(get_option "@extrakto_fzf_tool")
-open_tool=$(get_option "@extrakto_open_tool")
-copy_key=$(get_option "@extrakto_copy_key")
-insert_key=$(get_option "@extrakto_insert_key")
+# options; note some of the values can be overwritten by capture()
+GRAB_AREA=$(get_option "@extrakto_grab_area")
+EXTRAKTO_OPT=$(get_option "@extrakto_default_opt")
+CLIP_TOOL=$(get_option "@extrakto_clip_tool")
+CLIP_TOOL_RUN=$(get_option "@extrakto_clip_tool_run")
+FZF_TOOL=$(get_option "@extrakto_fzf_tool")
+OPEN_TOOL=$(get_option "@extrakto_open_tool")
+COPY_KEY=$(get_option "@extrakto_copy_key")
+INSERT_KEY=$(get_option "@extrakto_insert_key")
 
-capture_pane_start=$(get_capture_pane_start "$grab_area")
-original_grab_area=${grab_area} # keep this so we can cycle between alternatives on fzf
+CAPTURE_PANE_START=$(get_capture_pane_start "$GRAB_AREA")
+ORIGINAL_GRAB_AREA=${GRAB_AREA} # keep this so we can cycle between alternatives on fzf
 
-if [[ "$clip_tool" == "auto" ]]; then
-    case "$(uname)" in
+if [[ "$CLIP_TOOL" == "auto" ]]; then
+    case "$PLATFORM" in
         'Linux')
             if [[ $(cat /proc/sys/kernel/osrelease) =~ 'Microsoft' ]]; then
-                clip_tool='clip.exe'
+                CLIP_TOOL='clip.exe'
             else
-                clip_tool='xclip -i -selection clipboard >/dev/null'
+                CLIP_TOOL='xclip -i -selection clipboard >/dev/null'
             fi
             ;;
-        'Darwin') clip_tool='pbcopy' ;;
+        'Darwin') CLIP_TOOL='pbcopy' ;;
         *) ;;
     esac
 fi
 
-if [[ "$open_tool" == "auto" ]]; then
-    case "$(uname)" in
-        'Linux') open_tool='xdg-open >/dev/null' ;;
-        'Darwin') open_tool='open' ;;
-        *) open_tool='' ;;
+if [[ "$OPEN_TOOL" == "auto" ]]; then
+    case "$PLATFORM" in
+        'Linux') OPEN_TOOL='xdg-open >/dev/null' ;;
+        'Darwin') OPEN_TOOL='open' ;;
+        *) OPEN_TOOL='' ;;
     esac
 fi
 
 if [[ -z $EDITOR ]]; then
-    # fallback
-    editor="vi"
+    _EDITOR="vi"  # fallback
 else
-    editor="$EDITOR"
+    _EDITOR="$EDITOR"
 fi
 
-function capture_panes() {
-    if [[ $grab_area =~ ^window\  ]]; then
+capture_panes() {
+    local pane captured
+
+    if [[ $GRAB_AREA =~ ^window\  ]]; then
         for pane in $(tmux list-panes -F "#{pane_active}:#{pane_id}"); do
             if [[ $pane =~ ^0: && ${pane:2} != ${LAST_ACTIVE_PANE} ]]; then
-                local captured+=$(tmux capture-pane -pJS ${capture_pane_start} -t ${pane:2})
-                local captured+=$'\n'
+                captured+=$(tmux capture-pane -pJS ${CAPTURE_PANE_START} -t ${pane:2})
+                captured+=$'\n'
             fi
         done
     fi
-    local captured+=$(tmux capture-pane -pJS ${capture_pane_start} -t !)
+    captured+=$(tmux capture-pane -pJS ${CAPTURE_PANE_START} -t !)
 
     echo "$captured"
 }
 
-function capture() {
+capture() {
+    local header extrakto_flags sel res key text tmux_pane_num
 
-    header="${insert_key}=insert, ${copy_key}=copy"
-    if [ -n "$open_tool" ]; then header="$header, ctrl-o=open"; fi
+    header="${INSERT_KEY}=insert, ${COPY_KEY}=copy"
+    if [ -n "$OPEN_TOOL" ]; then header="$header, ctrl-o=open"; fi
     header="$header, ctrl-e=edit"
-    header="$header, ctrl-f=toggle filter [$extrakto_opt], ctrl-g=grab area [$grab_area]"
+    header="$header, ctrl-f=toggle filter [$EXTRAKTO_OPT], ctrl-g=grab area [$GRAB_AREA]"
 
-    case $extrakto_opt in
+    case "$EXTRAKTO_OPT" in
         'path/url') extrakto_flags='pu' ;;
         'lines') extrakto_flags='l' ;;
         *) extrakto_flags='w' ;;
@@ -77,53 +80,52 @@ function capture() {
     # for troubleshooting add
     # tee /tmp/stageN | \
     # between the commands
-    sel=$(capture_panes \
-        | $extrakto -r$extrakto_flags \
+    sel="$(capture_panes \
+        | $EXTRAKTO -r$extrakto_flags \
         | (read line && (
-            echo $line
+            echo "$line"
             cat
-        ) || echo NO MATCH - use a different filter) \
-        | $fzf_tool \
+        ) || echo 'NO MATCH - use a different filter') \
+        | $FZF_TOOL \
             --header="$header" \
-            --expect=${insert_key},${copy_key},ctrl-e,ctrl-f,ctrl-g,ctrl-o,ctrl-c,esc \
-            --tiebreak=index)
+            --expect=${INSERT_KEY},${COPY_KEY},ctrl-e,ctrl-f,ctrl-g,ctrl-o,ctrl-c,esc \
+            --tiebreak=index)"
 
     res=$?
     key=$(head -1 <<< "$sel")
     text=$(tail -n +2 <<< "$sel")
 
-    if [ $res -gt 0 -a "$key" == "" ]; then
+    if [[ $res -gt 0 && -z "$key" ]]; then
         echo "error: unable to extract - check/report errors above"
         echo "You can also set the fzf path in options (see readme)."
-        read
+        read  # pause
         exit
     fi
 
-    case $key in
-
-        ${copy_key})
+    case "$key" in
+        "${COPY_KEY}")
             tmux set-buffer -- "$text"
-            if [[ "$clip_tool_run" == "fg" ]]; then
+            if [[ "$CLIP_TOOL_RUN" == "fg" ]]; then
                 # run in foreground as OSC-52 copying won't work otherwise
-                tmux run-shell "tmux show-buffer|$clip_tool"
+                tmux run-shell "tmux show-buffer|$CLIP_TOOL"
             else
                 # run in background as xclip won't work otherwise
-                tmux run-shell -b "tmux show-buffer|$clip_tool"
+                tmux run-shell -b "tmux show-buffer|$CLIP_TOOL"
             fi
             ;;
 
-        ${insert_key})
+        "${INSERT_KEY}")
             tmux set-buffer -- "$text"
             tmux paste-buffer -t !
             ;;
 
         ctrl-f)
-            if [[ $extrakto_opt == 'word' ]]; then
-                extrakto_opt='path/url'
-            elif [[ $extrakto_opt == 'path/url' ]]; then
-                extrakto_opt='lines'
+            if [[ $EXTRAKTO_OPT == 'word' ]]; then
+                EXTRAKTO_OPT='path/url'
+            elif [[ $EXTRAKTO_OPT == 'path/url' ]]; then
+                EXTRAKTO_OPT='lines'
             else
-                extrakto_opt='word'
+                EXTRAKTO_OPT='word'
             fi
             capture
             ;;
@@ -132,56 +134,56 @@ function capture() {
             # cycle between options like this:
             # recent -> full -> window recent -> window full -> custom (if any) -> recent ...
             tmux_pane_num=$(tmux list-panes | wc -l)
-            if [[ $grab_area == "recent" ]]; then
+            if [[ $GRAB_AREA == "recent" ]]; then
                 if [[ $tmux_pane_num -eq 2 ]]; then
-                    grab_area="full"
+                    GRAB_AREA="full"
                 else
-                    grab_area="window recent"
+                    GRAB_AREA="window recent"
                 fi
-            elif [[ $grab_area == "window recent" ]]; then
-                grab_area="full"
-            elif [[ $grab_area == "full" ]]; then
+            elif [[ $GRAB_AREA == "window recent" ]]; then
+                GRAB_AREA="full"
+            elif [[ $GRAB_AREA == "full" ]]; then
                 if [[ $tmux_pane_num -eq 2 ]]; then
-                    grab_area="recent"
+                    GRAB_AREA="recent"
 
-                    if [[ ! "$original_grab_area" =~ ^(window )?(recent|full)$ ]]; then
-                        grab_area="$original_grab_area"
+                    if [[ ! "$ORIGINAL_GRAB_AREA" =~ ^(window )?(recent|full)$ ]]; then
+                        GRAB_AREA="$ORIGINAL_GRAB_AREA"
                     fi
                 else
-                    grab_area="window full"
+                    GRAB_AREA="window full"
                 fi
-            elif [[ $grab_area == "window full" ]]; then
-                grab_area="recent"
+            elif [[ $GRAB_AREA == "window full" ]]; then
+                GRAB_AREA="recent"
 
-                if [[ ! "$original_grab_area" =~ ^(window )?(recent|full)$ ]]; then
-                    grab_area="$original_grab_area"
+                if [[ ! "$ORIGINAL_GRAB_AREA" =~ ^(window )?(recent|full)$ ]]; then
+                    GRAB_AREA="$ORIGINAL_GRAB_AREA"
                 fi
             else
-                grab_area="recent"
+                GRAB_AREA="recent"
             fi
 
-            capture_pane_start=$(get_capture_pane_start "$grab_area")
+            CAPTURE_PANE_START=$(get_capture_pane_start "$GRAB_AREA")
 
             capture
             ;;
 
         ctrl-o)
-            if [ -n "$open_tool" ]; then
-                tmux run-shell -b "cd $PWD; $open_tool $text"
+            if [[ -n "$OPEN_TOOL" ]]; then
+                tmux run-shell -b "cd -- $PWD; $OPEN_TOOL $text"
             else
                 capture
             fi
             ;;
 
         ctrl-e)
-            tmux send-keys -t ! "$editor -- $text" 'C-m'
+            tmux send-keys -t ! "$_EDITOR -- $text" 'C-m'
             ;;
     esac
 }
 
 # check terminal size, zoom pane if too small
 lines=$(tput lines)
-if [ $lines -lt 7 ]; then
+if [[ $lines -lt 7 ]]; then
     tmux resize-pane -Z
 fi
 

--- a/scripts/tmux-extrakto.sh
+++ b/scripts/tmux-extrakto.sh
@@ -19,6 +19,18 @@ INSERT_KEY=$(get_option "@extrakto_insert_key")
 CAPTURE_PANE_START=$(get_capture_pane_start "$GRAB_AREA")
 ORIGINAL_GRAB_AREA=${GRAB_AREA} # keep this so we can cycle between alternatives on fzf
 
+declare -Ar COLORS=(
+    [RED]=$'\033[0;31m'
+    [GREEN]=$'\033[0;32m'
+    [BLUE]=$'\033[0;34m'
+    [PURPLE]=$'\033[0;35m'
+    [CYAN]=$'\033[0;36m'
+    [WHITE]=$'\033[0;37m'
+    [YELLOW]=$'\033[0;33m'
+    [OFF]=$'\033[0m'
+    [BOLD]=$'\033[1m'
+)
+
 
 # note we use the superfluous 'local' keyword in front of 'captured' var;
 # without it we get intermittent issues with extracto python script (when reading stdin);
@@ -43,9 +55,11 @@ capture_panes() {
 capture() {
     local header_tmpl header extrakto_flags out res key text tmux_pane_num query
 
-    header_tmpl="${INSERT_KEY}=insert, ${COPY_KEY}=copy"
-    [[ -n "$OPEN_TOOL" ]] && header_tmpl+=', ctrl-o=open'
-    header_tmpl+=', ctrl-e=edit, ctrl-f=toggle filter [{eo}], ctrl-g=grab area [{ga}]'
+    header_tmpl="${COLORS[BOLD]}${INSERT_KEY}${COLORS[OFF]}=insert, ${COLORS[BOLD]}${COPY_KEY}${COLORS[OFF]}=copy"
+    [[ -n "$OPEN_TOOL" ]] && header_tmpl+=", ${COLORS[BOLD]}ctrl-o${COLORS[OFF]}=open"
+    header_tmpl+=", ${COLORS[BOLD]}ctrl-e${COLORS[OFF]}=edit, \
+${COLORS[BOLD]}ctrl-f${COLORS[OFF]}=toggle filter [${COLORS[YELLOW]}${COLORS[BOLD]}{eo}${COLORS[OFF]}], \
+${COLORS[BOLD]}ctrl-g${COLORS[OFF]}=grab area [${COLORS[YELLOW]}${COLORS[BOLD]}{ga}${COLORS[OFF]}]"
 
     while true; do
         header="$header_tmpl"


### PR DESCRIPTION
    
    
    - minor bash cleanup, such as:
      - variable localization
      - use bash syntax (eg [[]] vs [])
      - improve param quoting
      - capitalize global parameters
    - preserve user input query in fzf between ctrl+f & ctrl+g options by
      utilizing --print-query fzf option;
    - instead of recursively calling capture(), run the command in a loop
      in capture();
    - add colors to fzf header
