### PR TITLE
Allow configuration of popup size and position

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Where `<option>` and `<value>` are one of the specified here:
 | `@extrakto_open_tool`       | `auto`  | Set this to path of your own tool or `auto` to use your platforms *open* implementation. |
 | `@extrakto_copy_key`        | `enter` | Key to copy selection to clipboard. |
 | `@extrakto_insert_key`      | `tab`   | Key to insert selection. |
+| `@extrakto_popup_size`      | `90%`   | Set width and height of the tmux popup window. Set this to `w,h` to set the width to `w` and height to `h`. |
+| `@extrakto_popup_position`  | `C`     | Set position of the tmux popup window. Possible values are in the `display-popup` entry in `man tmux`. Set this to `x,y` to set the x and y positions to `x` and `y` respectively. |
 
 
 Example:

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-popup_default_size="90%"
-popup_default_position="C"
-
 get_tmux_option() {
     local option default_value option_value
 
@@ -66,11 +63,11 @@ get_option() {
             ;;
 
         "@extrakto_popup_size")
-            echo $(get_tmux_option $option "$popup_default_size,$popup_default_size")
+            echo $(get_tmux_option $option "90%")
             ;;
 
         "@extrakto_popup_position")
-            echo $(get_tmux_option $option "$popup_default_position,$popup_default_position")
+            echo $(get_tmux_option $option "C")
             ;;
     esac
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -61,6 +61,14 @@ get_option() {
         "@extrakto_clip_tool_run")
             echo $(get_tmux_option $option "bg")
             ;;
+
+        "@extrakto_popup_size")
+            echo $(get_tmux_option $option "90%,90%")
+            ;;
+
+        "@extrakto_popup_position")
+            echo $(get_tmux_option $option "C,C")
+            ;;
     esac
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+popup_default_size="90%"
+popup_default_position="C"
+
 get_tmux_option() {
     local option default_value option_value
 
@@ -63,11 +66,11 @@ get_option() {
             ;;
 
         "@extrakto_popup_size")
-            echo $(get_tmux_option $option "90%,90%")
+            echo $(get_tmux_option $option "$popup_default_size,$popup_default_size")
             ;;
 
         "@extrakto_popup_position")
-            echo $(get_tmux_option $option "C,C")
+            echo $(get_tmux_option $option "$popup_default_position,$popup_default_position")
             ;;
     esac
 }

--- a/scripts/open.sh
+++ b/scripts/open.sh
@@ -17,13 +17,13 @@ if [[ $split_direction == a ]]; then
 fi
 
 if [[ $split_direction == p ]]; then
-    popup_size=$(get_option "@extrakto_popup_size")
-    popup_position=$(get_option "@extrakto_popup_position")
-    popup_width=$(echo $popup_size | awk -F ',' '{ print $1 }')
-    popup_height=$(echo $popup_size | awk -F ',' '{ print $2 }')
-    popup_x=$(echo $popup_position | awk -F ',' '{ print $1 }')
-    popup_y=$(echo $popup_position | awk -F ',' '{ print $2 }')
-    tmux popup -w ${popup_width} -h ${popup_height} -x ${popup_x} -y ${popup_y} \
+    IFS=, read popup_width popup_height <<< "$(get_option "@extrakto_popup_size")"
+    IFS=, read popup_x popup_y <<< "$(get_option "@extrakto_popup_position")"
+    tmux popup \
+        -w ${popup_width:-$popup_default_size} \
+        -h ${popup_height:-$popup_default_size} \
+        -x ${popup_x:-$popup_default_position} \
+        -y ${popup_y:-$popup_default_position} \
         -KER "${extrakto} ${pane_id} popup"
 else
     split_size=$(get_option "@extrakto_split_size")

--- a/scripts/open.sh
+++ b/scripts/open.sh
@@ -20,10 +20,10 @@ if [[ $split_direction == p ]]; then
     IFS=, read popup_width popup_height <<< "$(get_option "@extrakto_popup_size")"
     IFS=, read popup_x popup_y <<< "$(get_option "@extrakto_popup_position")"
     tmux popup \
-        -w ${popup_width:-$popup_default_size} \
-        -h ${popup_height:-$popup_default_size} \
-        -x ${popup_x:-$popup_default_position} \
-        -y ${popup_y:-$popup_default_position} \
+        -w ${popup_width} \
+        -h ${popup_height:-$popup_width} \
+        -x ${popup_x} \
+        -y ${popup_y:-$popup_x} \
         -KER "${extrakto} ${pane_id} popup"
 else
     split_size=$(get_option "@extrakto_split_size")

--- a/scripts/open.sh
+++ b/scripts/open.sh
@@ -7,7 +7,6 @@ extrakto="$current_dir/extrakto.sh"
 
 pane_id=$1
 split_direction=$(get_option "@extrakto_split_direction")
-split_size=$(get_option "@extrakto_split_size")
 
 if [[ $split_direction == a ]]; then
     if [[ -n $(tmux list-commands popup) ]]; then
@@ -18,7 +17,15 @@ if [[ $split_direction == a ]]; then
 fi
 
 if [[ $split_direction == p ]]; then
-    tmux popup -w90% -h90% -KER "${extrakto} ${pane_id} popup"
+    popup_size=$(get_option "@extrakto_popup_size")
+    popup_position=$(get_option "@extrakto_popup_position")
+    popup_width=$(echo $popup_size | awk -F ',' '{ print $1 }')
+    popup_height=$(echo $popup_size | awk -F ',' '{ print $2 }')
+    popup_x=$(echo $popup_position | awk -F ',' '{ print $1 }')
+    popup_y=$(echo $popup_position | awk -F ',' '{ print $2 }')
+    tmux popup -w ${popup_width} -h ${popup_height} -x ${popup_x} -y ${popup_y} \
+        -KER "${extrakto} ${pane_id} popup"
 else
+    split_size=$(get_option "@extrakto_split_size")
     tmux split-window -${split_direction} -l ${split_size} "${extrakto} ${pane_id} split"
 fi


### PR DESCRIPTION
This is a quick-and-dirty implementation of allowing the user to
configure the popup size and position.

Popup size is set using `@extrakto_popup_size`, which takes a
comma-separated argument specifying width and height (in that order).

Popup position is set similarly using `@extrakto_popup_position` for the
x and y positions of the popup window, as in the description of
`display-menu` and `display-popup` in `man tmux`.

This implementation lacks (and sorely needs) input validation. It will
break as soon as the user chooses to provide only one of the width
or height. The same goes for the x/y positions.

I'm not a huge fan of the way I use `awk` to parse the options (do I
really need an `echo` there?), but it should be portable across
different versions of awk.

I'll update this pull request when I find time to work out the kinks I
outlined above.