### PR TITLE
Add support for WSL2

### DIFF
--- a/scripts/extrakto.sh
+++ b/scripts/extrakto.sh
@@ -45,7 +45,7 @@ original_grab_area=${grab_area} # keep this so we can cycle between alternatives
 if [[ "$clip_tool" == "auto" ]]; then
     case "$platform" in
         'Linux')
-            if [[ $(cat /proc/sys/kernel/osrelease) =~ 'Microsoft' ]]; then
+            if [[ $(cat /proc/sys/kernel/osrelease) =~ Microsoft|microsoft ]]; then
                 clip_tool='clip.exe'
             else
                 clip_tool='xclip -i -selection clipboard >/dev/null'


### PR DESCRIPTION
In recent versions of WSL2, the `/proc/sys/kernel/osrelease` has changed -- the string "microsoft" can now be lower case.
```
> cat /proc/sys/kernel/osrelease
4.19.128-microsoft-standard
```
This one-word (nice!) PR fixes the error where extrakto tries to use `xclip` on WSL2.