### PR TITLE
Ensure open.sh handles tmux-popup error return

### DIFF
--- a/scripts/open.sh
+++ b/scripts/open.sh
@@ -19,12 +19,15 @@ fi
 if [[ $split_direction == p ]]; then
     IFS=, read popup_width popup_height <<< "$(get_option "@extrakto_popup_size")"
     IFS=, read popup_x popup_y <<< "$(get_option "@extrakto_popup_position")"
-    tmux popup \
-        -w ${popup_width} \
-        -h ${popup_height:-$popup_width} \
-        -x ${popup_x} \
-        -y ${popup_y:-$popup_x} \
-        -KER "${extrakto} ${pane_id} popup"
+    while :; do
+        tmux popup \
+            -w ${popup_width} \
+            -h ${popup_height:-$popup_width} \
+            -x ${popup_x} \
+            -y ${popup_y:-$popup_x} \
+            -KER "${extrakto} ${pane_id} popup"
+        [[ $? -eq 129 ]] || break
+    done
 else
     split_size=$(get_option "@extrakto_split_size")
     tmux split-window -${split_direction} -l ${split_size} "${extrakto} ${pane_id} split"


### PR DESCRIPTION
If the tmux session window is resized while a popup is visible, the popup automatically terminates and `tmux popup` returns with exit code 129

This results in `tmux` displaying a full-pane error page `extrakto/open.sh failed with error code 129'.

This change ensures the popup is re-opened with the new (automatically scaled to the new window size by default) and avoids the tmux error pane.

Note that resizing the window will cause fzf to be re-launched, losing any existing search.
