### PR TITLE
Turn off remain-on-exit for the split-window popup.

### DIFF
--- a/scripts/open.sh
+++ b/scripts/open.sh
@@ -32,5 +32,5 @@ if [[ $split_direction == p ]]; then
     exit $rc
 else
     split_size=$(get_option "@extrakto_split_size")
-    tmux split-window -${split_direction} -l ${split_size} "${extrakto} ${pane_id} split"
+    tmux split-window -${split_direction} -l ${split_size} "tmux setw remain-on-exit off; ${extrakto} ${pane_id} split"
 fi


### PR DESCRIPTION
If you have remain-on-exit set to on, and use the split-window popup, you'll have a zombie window left over unless remain-on-exit is explicitly turned off.