### PR TITLE
extrakto.py: fix type for --min-length command line argument

### DIFF
--- a/extrakto.py
+++ b/extrakto.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
 
     parser.add_argument("-r", "--reverse", action="store_true", help="reverse output")
 
-    parser.add_argument("-m", "--min-length", default=5, help="minimum token length")
+    parser.add_argument("-m", "--min-length", default=5, help="minimum token length", type=int)
 
     parser.add_argument(
         "--warn-empty", action="store_true", help="warn if result is empty"


### PR DESCRIPTION
By default, ArgumentParser returns a string; however, in the case of --min-length, an integer is the type that is needed.

The original behaviour resulted in a TypeError exception:
`TypeError: '>=' not supported between instances of 'int' and 'str'`