### PR TITLE
Drop tmux display-popup -KR arguments

### DIFF
--- a/scripts/open.sh
+++ b/scripts/open.sh
@@ -26,7 +26,7 @@ if [[ $split_direction == p ]]; then
             -h ${popup_height:-$popup_width} \
             -x ${popup_x} \
             -y ${popup_y:-$popup_x} \
-            -KER "${extrakto} ${pane_id} popup"
+            -E "${extrakto} ${pane_id} popup"
         rc=$?
     done
     exit $rc


### PR DESCRIPTION
Extrakto fails with tmux-3.2-rc4:
```
$ ./.tmux/plugins/extrakto/scripts/open.sh
tmux: unknown option -- K
usage: display-popup [-CE] [-c target-client] [-d start-directory] [-h height] [-t target-pane] [-w width] [-x position] [-y position] [command]
```

-K is now default behavior:
https://github.com/tmux/tmux/commit/c44750792a9683c5cd6f9df5a69e7417b88772d2