### PR TITLE
Use a POSIX compliant method of lowercasing instead of Bash 4 method.

### DIFF
--- a/extrakto.tmux
+++ b/extrakto.tmux
@@ -7,6 +7,6 @@ extrakto_open="$CURRENT_DIR/scripts/open.sh"
 
 extrakto_key=$(get_option "@extrakto_key")
 
-if [[ ${extrakto_key,,} != none ]]; then
+if [[ $(echo $extrakto_key | tr [:upper:] [:lower:] ) != none ]]; then
     tmux bind-key ${extrakto_key} run-shell "\"$extrakto_open\" \"#{pane_id}\""
 fi


### PR DESCRIPTION
The fix for this issue(#61), used a Bash 4 method of lowercasing the `extrakto_key` option.
This caused the plugin to crash on pre-4 Bash. This happens before the `Please update bash...` message.

This PR changes that syntax to a POSIX compliant mechanism of `tr`.

Reference:
https://stackoverflow.com/a/2264537/3395659