### PR TITLE
Fix an issue where the FZF pane/popup will stay open after opening the selected item

### DIFF
--- a/scripts/extrakto.sh
+++ b/scripts/extrakto.sh
@@ -242,6 +242,7 @@ capture() {
 
             "${open_key}")
                 open "$text"
+                return 0
                 ;;
 
             "${edit_key}")


### PR DESCRIPTION
I perceive this as a bug because it's expected that opening the item will result
in closing the popup/pane just like when yanking.