### PR TITLE
(Related to issue #72) Added configuration variable for defining the order of filter modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Where `<option>` and `<value>` are one of the specified here:
 | `@extrakto_grab_key`        | `ctrl-g` | Key to toggle grab mode. |
 | `@extrakto_edit_key`        | `ctrl-e` | Key to run the editor. |
 | `@extrakto_open_key`        | `ctrl-o` | Key to run the open command. |
+| `@extrakto_filter_order`    | `word all line` | Filter modes order |
 | `@extrakto_default_opt`     | `word`   | **LEGACY** this option was removed in favor of the new filter mode. |
 
 Example:

--- a/scripts/extrakto.sh
+++ b/scripts/extrakto.sh
@@ -134,8 +134,8 @@ show_fzf_error() {
 }
 
 sanitize_modes_list() {
-    local -a default=("all" "line" "word")
-    local -A valid_modes=(["all"]=1 ["line"]=1 ["word"]=1)
+    local -a default=("word" "all" "line")
+    local -A valid_modes=(["word"]=1 ["all"]=1 ["line"]=1)
 
     local invalid=1
     for mode in ${modes_list[@]}; do

--- a/scripts/extrakto.sh
+++ b/scripts/extrakto.sh
@@ -30,6 +30,9 @@ declare -Ar COLORS=(
     [BOLD]=$'\033[1m'
 )
 
+declare -A next_mode
+declare -a modes_list
+
 # options; note some of the values can be overwritten by capture()
 grab_area=$(get_option "@extrakto_grab_area")
 clip_tool=$(get_option "@extrakto_clip_tool")
@@ -130,10 +133,48 @@ show_fzf_error() {
     read # pause
 }
 
+sanitize_modes_list() {
+    local -a default=("all" "line" "word")
+    local -A valid_modes=(["all"]=1 ["line"]=1 ["word"]=1)
+
+    local invalid=1
+    for mode in ${modes_list[@]}; do
+        if [[ ${valid_modes[$mode]} -ne 1 ]]; then
+            invalid=0
+            break
+        fi
+    done
+
+    if $invalid; then
+        # change $modes_list to $default
+        for i in ${!default[@]}; do
+            modes_list[$i]=${default[$i]}
+        done
+    fi
+}
+
+#transform the modes_list got from @extraktor_filter_order into
+#the more usable form of associative array
+mk_next_mode_list() {
+
+    for i in ${!modes_list[@]}; do
+        if [[ $i -eq $((${#modes_list}-1)) ]]; then
+            next_mode+=([${modes_list[$i]}]=${modes_list[0]})
+        else
+            next_mode+=([${modes_list[$i]}]=${modes_list[$((i+1))]})
+        fi
+    done
+
+}
+
 capture() {
     local mode header_tmpl header out res key text query
 
-    mode=word
+    readarray -td ' ' modes_list <<<"$(get_option @extrakto_filter_order) "; unset 'modes_list[-1]'
+    sanitize_modes_list
+    mk_next_mode_list
+    mode=${modes_list[0]}
+
     header_tmpl="${COLORS[BOLD]}${insert_key}${COLORS[OFF]}=insert"
     header_tmpl+=", ${COLORS[BOLD]}${copy_key}${COLORS[OFF]}=copy"
     [[ -n "$open_tool" ]] && header_tmpl+=", ${COLORS[BOLD]}${open_key}${COLORS[OFF]}=open"
@@ -197,13 +238,7 @@ capture() {
                 ;;
 
             "${filter_key}")
-                if [[ $mode == all ]]; then
-                    mode=line
-                elif [[ $mode == line ]]; then
-                    mode=word
-                else
-                    mode=all
-                fi
+                mode=${next_mode[$mode]}
                 ;;
 
             "${grab_key}")

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -91,7 +91,7 @@ get_option() {
             ;;
 
         "@extrakto_filter_order")
-            echo $(get_tmux_option $option "all line word")
+            echo $(get_tmux_option $option "word all line")
             ;;
     esac
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -90,6 +90,9 @@ get_option() {
             echo $(get_tmux_option $option "default")
             ;;
 
+        "@extrakto_filter_order")
+            echo $(get_tmux_option $option "all line word")
+            ;;
     esac
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -123,3 +123,70 @@ get_capture_pane_start() {
 
     echo "$capture_start"
 }
+
+# Implement ordered filters list as defined by @extrakto_filter_order
+declare -A next_mode
+declare -a modes_list
+
+# If there is a bogus filter mode name in the list,
+# fall back to the default list of "word all line"
+# Just removing the bogus items would be another
+# valid option, but I think it's better to clearly
+# signify the user that there's something wrong
+# with their config, while not completely break
+# the plugin
+sanitize_modes_list() {
+    # in case of further "first class" filter modes implemented in the future
+    # add their names to the following default list and valid_modes set
+    local -a default=("word" "all" "line")
+    local -A valid_modes=(["word"]=1 ["all"]=1 ["line"]=1)
+
+    local invalid=false
+    for mode in ${modes_list[@]}; do
+        if [[ ${valid_modes[$mode]} -ne 1 ]]; then
+            invalid=true
+            break
+        fi
+    done
+
+    if  [ $invalid == true ]; then
+        # change $modes_list to $default
+        for i in ${!default[@]}; do
+            modes_list[$i]=${default[$i]}
+        done
+    fi
+}
+
+#transform the modes_list acquired from @extrakto_filter_order into
+#the more usable form of associative array
+mk_next_mode_map() {
+    for i in ${!modes_list[@]}; do
+        if [[ $i -eq $((${#modes_list[@]}-1)) ]]; then
+            next_mode+=([${modes_list[$i]}]=${modes_list[0]})
+        else
+            next_mode+=([${modes_list[$i]}]=${modes_list[$((i+1))]})
+        fi
+    done
+}
+
+#initialize
+modes_list_init() {
+    readarray -td ' ' modes_list <<<"$(get_option @extrakto_filter_order) "; unset 'modes_list[-1]'
+    sanitize_modes_list
+    mk_next_mode_map
+}
+
+
+# get next mode in ordered defined by @extrakto_filter_order
+get_next_mode() {
+    if [[ ${#modes_list[@]} -eq 0 || ${#next_mode[@]} -le ${#modes_list[@]} ]]; then
+        modes_list_init
+    fi
+
+    local next=$1
+    if [ $next == "initial" ]; then
+        echo ${modes_list[0]}
+    else
+        echo ${next_mode[$next]}
+    fi
+}


### PR DESCRIPTION
>  Originally from issue #72 [How to make the default filter as "lines"?].
>   but it seems better to generalize the config to not just simply let the
>   user define the "default" (or in fact the first) filter in the list, but
>   the whole filter list in order as well.

Feel free to comment on any change needed, I would really appreciate that. I wouldn't call myself a bash expert, most of the time I just use bash as my go-to quick fix duck tape so can't be confident what I wrote doesn't deviate much from best practices (if bash even has those). The readarray builtin for example was something I found convenient here, but it wasn't available until bash 4.0 or so, if backward compatibility with older bash versions was important for this project then I'd change it to good old read instead.