### PR TITLE
Add support for Wayland (wl-copy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Use it for paths, URLs, options from a man page, git hashes, docker container na
 
 Supported clipboards:
 
-- Linux (xclip)
+- Linux Xorg (xclip) and Wayland (wl-copy)
 - macOS (pbcopy)
 - WSL (aka "Bash on Windows")
 - *bring your own*

--- a/scripts/extrakto.sh
+++ b/scripts/extrakto.sh
@@ -53,6 +53,8 @@ if [[ "$clip_tool" == "auto" ]]; then
         'Linux')
             if [[ $(cat /proc/sys/kernel/osrelease) =~ Microsoft|microsoft ]]; then
                 clip_tool='clip.exe'
+            elif [[ $XDG_SESSION_TYPE == "wayland" ]]; then
+                clip_tool='wl-copy'
             else
                 clip_tool='xclip -i -selection clipboard >/dev/null'
             fi


### PR DESCRIPTION
Hey! I noticed that extrakto failed to detect the right clipboard tool on Wayland and updated the script to use `wl-copy` in that case.  I hope it helps!