### PR TITLE
add support for multiple selections

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -18,6 +18,8 @@ Extrakto uses fzf. You only need to type a few keys to find your selection with 
 
 - Press *esc* or *ctrl-c* to cancel
 
+- Use *shift-tab* to select multiple entries.
+
 Actions that use the current selection:
 
 - Press *tab* to insert the selection into the active tmux pane (*insert_key*).


### PR DESCRIPTION
The selection elements are joined by newlines (line mode), or spaces (other modes). To ensure the pasted text is not interpreted, `tmux paste-buffer` bracketed mode is now used.

Close #79.