### PR TITLE
Utilise native support for OSC 52 with the -w option - Fixes #92

### DIFF
--- a/scripts/extrakto.sh
+++ b/scripts/extrakto.sh
@@ -83,7 +83,7 @@ copy() {
         # run in foreground as OSC-52 copying won't work otherwise
         tmux set-buffer -- "$1"
         tmux run-shell "tmux show-buffer|$clip_tool"
-    elif [[ "$clip_tool" == "tmux_osc52" ]]; then
+    elif [[ "$clip_tool_run" == "tmux_osc52" ]]; then
         # use native tmux 3.2 OSC 52 functionality
         tmux set-buffer -w -- "$1"
     else

--- a/scripts/extrakto.sh
+++ b/scripts/extrakto.sh
@@ -79,14 +79,20 @@ else
 fi
 
 copy() {
-    tmux set-buffer -- "$1"
-    if [[ "$clip_tool_run" == "fg" ]]; then
-        # run in foreground as OSC-52 copying won't work otherwise
-        tmux run-shell "tmux show-buffer|$clip_tool"
+    if [[ "$clip_tool" == "osc52" ]]; then
+        # copy to OSC 52 with -w
+        tmux set-buffer -w -- "$1"
     else
-        # run in background as xclip won't work otherwise
-        tmux run-shell -b "tmux show-buffer|$clip_tool"
+        tmux set-buffer -- "$1"
+        if [[ "$clip_tool_run" == "fg" ]]; then
+            # run in foreground as OSC-52 copying won't work otherwise
+            tmux run-shell "tmux show-buffer|$clip_tool"
+        else
+            # run in background as xclip won't work otherwise
+            tmux run-shell -b "tmux show-buffer|$clip_tool"
+        fi
     fi
+
 }
 
 open() {

--- a/scripts/extrakto.sh
+++ b/scripts/extrakto.sh
@@ -79,20 +79,18 @@ else
 fi
 
 copy() {
-    if [[ "$clip_tool" == "osc52" ]]; then
-        # copy to OSC 52 with -w
+    if [[ "$clip_tool_run" == "fg" ]]; then
+        # run in foreground as OSC-52 copying won't work otherwise
+        tmux set-buffer -- "$1"
+        tmux run-shell "tmux show-buffer|$clip_tool"
+    elif [[ "$clip_tool" == "tmux_osc52" ]]; then
+        # use native tmux 3.2 OSC 52 functionality
         tmux set-buffer -w -- "$1"
     else
+        # run in background as xclip won't work otherwise
         tmux set-buffer -- "$1"
-        if [[ "$clip_tool_run" == "fg" ]]; then
-            # run in foreground as OSC-52 copying won't work otherwise
-            tmux run-shell "tmux show-buffer|$clip_tool"
-        else
-            # run in background as xclip won't work otherwise
-            tmux run-shell -b "tmux show-buffer|$clip_tool"
-        fi
+        tmux run-shell -b "tmux show-buffer|$clip_tool"
     fi
-
 }
 
 open() {


### PR DESCRIPTION
This uses the `-w` option for the `set-buffer` command which implements OSC 52 support. This fixes my issue in #92.