### PR TITLE
Add extra modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,26 +72,27 @@ set -g <option> "<value>"
 
 Where `<option>` and `<value>` are one of the specified here:
 
-| Option                      | Default         | Description |
-| :---                        | :---:           | :--- |
-| `@extrakto_key`             | `tab`           | The key binding to start. If you have any special requirements (like a custom key table) set this to 'none' and define a binding in your `.tmux.conf`. See `extrakto.tmux` for a sample. |
-| `@extrakto_split_direction` | `a`             | Whether the tmux split will be `a`uto, `p`opup, `v`ertical or `h`orizontal |
-| `@extrakto_split_size`      | `7`             | The size of the tmux split (for vertical/horizontal) |
-| `@extrakto_popup_size`      | `90%`           | Set width and height of the tmux popup window. Set this to `w,h` to set the width to `w` and height to `h`. |
-| `@extrakto_popup_position`  | `C`             | Set position of the tmux popup window. Possible values are in the `display-popup` entry in `man tmux`. Set this to `x,y` to set the x and y positions to `x` and `y` respectively. |
-| `@extrakto_grab_area`       | `full`          | Whether you want extrakto to grab data from the `recent` area, the `full` pane, all current window's `recent` areas or all current window's `full` panes. You can also set this option to any number you want (or number preceded by "window ", e.g. "window 500"), this allows you to grab a smaller amount of data from the pane(s) than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto. |
-| `@extrakto_clip_tool`       | `auto`          | Set this to whatever clipboard tool you would like extrakto to use to copy data into your clipboard. `auto` will try to choose the correct clipboard for your platform. |
-| `@extrakto_clip_tool_run`   | `bg`            | Set this to `tmux_osc52` to enable [remote clipboard support](https://github.com/laktak/extrakto/wiki/Remote-Copy-via-OSC52) or `fg`/`bg` to have your clipboard tool run in a foreground/background shell. |
-| `@extrakto_fzf_tool`        | `fzf`           | Set this to path of fzf if it can't be found in your `PATH`. |
-| `@extrakto_fzf_layout`      |`default`        | Control the fzf layout which is "bottom-up" by default. If you prefer "top-down" layout instead set this to `reverse`. In fact, this value is passed to the fzf `--layout` parameter. Possible values are: `default`, `reverse` and `reverse-list` |
-| `@extrakto_open_tool`       | `auto`          | Set this to path of your own tool or `auto` to use your platforms *open* implementation. |
-| `@extrakto_copy_key`        | `enter`         | Key to copy selection to clipboard. |
-| `@extrakto_insert_key`      | `tab`           | Key to insert selection. |
-| `@extrakto_filter_key`      | `ctrl-f`        | Key to toggle filter mode. |
-| `@extrakto_grab_key`        | `ctrl-g`        | Key to toggle grab mode. |
-| `@extrakto_edit_key`        | `ctrl-e`        | Key to run the editor. |
-| `@extrakto_open_key`        | `ctrl-o`        | Key to run the open command. |
-| `@extrakto_filter_order`    | `word all line` | Filter modes order. The first listed mode will be the default when opening extrakto. |
+| Option                                | Default         | Description |
+| :---                                  | :---:           | :--- |
+| `@extrakto_key`                       | `tab`           | The key binding to start. If you have any special requirements (like a custom key table) set this to 'none' and define a binding in your `.tmux.conf`. See `extrakto.tmux` for a sample. |
+| `@extrakto_split_direction`           | `a`             | Whether the tmux split will be `a`uto, `p`opup, `v`ertical or `h`orizontal |
+| `@extrakto_split_size`                | `7`             | The size of the tmux split (for vertical/horizontal) |
+| `@extrakto_popup_size`                | `90%`           | Set width and height of the tmux popup window. Set this to `w,h` to set the width to `w` and height to `h`. |
+| `@extrakto_popup_position`            | `C`             | Set position of the tmux popup window. Possible values are in the `display-popup` entry in `man tmux`. Set this to `x,y` to set the x and y positions to `x` and `y` respectively. |
+| `@extrakto_grab_area`                 | `full`          | Whether you want extrakto to grab data from the `recent` area, the `full` pane, all current window's `recent` areas or all current window's `full` panes. You can also set this option to any number you want (or number preceded by "window ", e.g. "window 500"), this allows you to grab a smaller amount of data from the pane(s) than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto. |
+| `@extrakto_clip_tool`                 | `auto`          | Set this to whatever clipboard tool you would like extrakto to use to copy data into your clipboard. `auto` will try to choose the correct clipboard for your platform. |
+| `@extrakto_clip_tool_run`             | `bg`            | Set this to `tmux_osc52` to enable [remote clipboard support](https://github.com/laktak/extrakto/wiki/Remote-Copy-via-OSC52) or `fg`/`bg` to have your clipboard tool run in a foreground/background shell. |
+| `@extrakto_fzf_tool`                  | `fzf`           | Set this to path of fzf if it can't be found in your `PATH`. |
+| `@extrakto_fzf_layout`                |`default`        | Control the fzf layout which is "bottom-up" by default. If you prefer "top-down" layout instead set this to `reverse`. In fact, this value is passed to the fzf `--layout` parameter. Possible values are: `default`, `reverse` and `reverse-list` |
+| `@extrakto_open_tool`                 | `auto`          | Set this to path of your own tool or `auto` to use your platforms *open* implementation. |
+| `@extrakto_copy_key`                  | `enter`         | Key to copy selection to clipboard. |
+| `@extrakto_insert_key`                | `tab`           | Key to insert selection. |
+| `@extrakto_filter_key`                | `ctrl-f`        | Key to toggle filter mode. |
+| `@extrakto_grab_key`                  | `ctrl-g`        | Key to toggle grab mode. |
+| `@extrakto_edit_key`                  | `ctrl-e`        | Key to run the editor. |
+| `@extrakto_open_key`                  | `ctrl-o`        | Key to run the open command. |
+| `@extrakto_filter_order`              | `word all line` | Filter modes order. The first listed mode will be the default when opening extrakto. |
+| `@extrakto_fzf_unset_default_opts`    | `true`          | Unsets custom FZF_DEFAULT_OPTS as it can potentially cause problems in extrakto operations |
 
 Example:
 
@@ -100,6 +101,7 @@ set -g @extrakto_split_size "15"
 set -g @extrakto_clip_tool "xsel --input --clipboard" # works better for nvim
 set -g @extrakto_copy_key "tab"      # use tab to copy to clipboard
 set -g @extrakto_insert_key "enter"  # use enter to insert selection
+set -g @extrakto_fzf_unset_default_opts "false"  # keep our custom FZF_DEFAULT_OPTS
 ```
 
 ## Custom Filters

--- a/extrakto.py
+++ b/extrakto.py
@@ -129,12 +129,16 @@ def main(parser):
     args = parser.parse_args()
 
     run_list = []
-    if args.words:
-        run_list.append("word")
     if args.paths:
         run_list.append("path")
+    if args.quote:
+        run_list.append("quote")
+    if args.squote:
+        run_list.append("s-quote")
     if args.urls:
         run_list.append("url")
+    if args.words:
+        run_list.append("word")
     run_list += args.add
 
     res = []
@@ -171,7 +175,12 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "-w", "--words", action="store_true", help='extract "word" tokens'
+        "-w",
+        "--words",
+        "--word",
+        dest="words",
+        action="store_true",
+        help='extract "word" tokens',
     )
 
     parser.add_argument("-l", "--lines", action="store_true", help="extract lines")
@@ -189,6 +198,12 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--paths", action="store_true", help="short for -a=path")
 
     parser.add_argument("-u", "--urls", action="store_true", help="short for -a=url")
+
+    parser.add_argument("-q", "--quote", action="store_true", help="short for -a=quote")
+
+    parser.add_argument(
+        "-s", "--squote", action="store_true", help="short for -a=s-quote"
+    )
 
     parser.add_argument(
         "--alt",

--- a/scripts/extrakto.sh
+++ b/scripts/extrakto.sh
@@ -157,13 +157,30 @@ capture() {
     header_tmpl+=", ${COLORS[BOLD]}${help_key}${COLORS[OFF]}=help"
 
     get_cap() {
-        if [[ $mode == all ]]; then
-            capture_panes | $extrakto --warn-empty --alt --all --name -r
-        elif [[ $mode == line ]]; then
-            capture_panes | $extrakto --warn-empty -rl
-        else
-            capture_panes | $extrakto --warn-empty -rw
-        fi
+        case "$mode" in
+            "all")
+                capture_panes | $extrakto --warn-empty --alt --all --name -r
+                ;;
+            "line")
+                capture_panes | $extrakto --warn-empty -rl
+                ;;
+            "path")
+                capture_panes | $extrakto --warn-empty -rp
+                ;;
+            "url")
+                capture_panes | $extrakto --warn-empty -ru
+                ;;
+            "quote")
+                capture_panes | $extrakto --warn-empty -rq
+                ;;
+            "s-quote")
+                capture_panes | $extrakto --warn-empty -rs
+                ;;
+            "word" | *)
+                capture_panes | $extrakto --warn-empty -rw
+                ;;
+
+        esac
     }
 
     while true; do

--- a/scripts/extrakto.sh
+++ b/scripts/extrakto.sh
@@ -44,9 +44,16 @@ edit_key=$(get_option "@extrakto_edit_key")
 grab_key=$(get_option "@extrakto_grab_key")
 help_key=$(get_option "@extrakto_help_key")
 fzf_layout=$(get_option "@extrakto_fzf_layout")
+fzf_unset_default_opts=$(get_option "@extrakto_fzf_unset_default_opts")
 
 capture_pane_start=$(get_capture_pane_start "$grab_area")
 original_grab_area=${grab_area} # keep this so we can cycle between alternatives on fzf
+
+# On many occasions, customized FZF_DEFAULT_OPTS will make our plugin behave
+# strangely.
+if [[ $fzf_unset_default_opts == "true" ]]; then
+    unset FZF_DEFAULT_OPTS
+fi
 
 if [[ "$clip_tool" == "auto" ]]; then
     case "$platform" in

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -93,6 +93,10 @@ get_option() {
         "@extrakto_filter_order")
             echo $(get_tmux_option $option "word all line")
             ;;
+
+        "@extrakto_fzf_unset_default_opts")
+            get_tmux_option "$option" "true"
+            ;;
     esac
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -138,7 +138,13 @@ sanitize_modes_list() {
     # in case of further "first class" filter modes implemented in the future
     # add their names to the following default list and valid_modes set
     local -a default=("word" "all" "line")
-    local -A valid_modes=(["word"]=1 ["all"]=1 ["line"]=1)
+    local -A valid_modes=(["word"]=1
+                          ["all"]=1
+                          ["line"]=1
+                          ["url"]=1
+                          ["path"]=1
+                          ["quote"]=1
+                          ["s-quote"]=1)
 
     local invalid=false
     for mode in ${modes_list[@]}; do


### PR DESCRIPTION
This is a reduced version of #103 


What this PR does:

## New variable
Introduces `extrakto_fzf_unset_default_opts` in order to unset the environment variable `FZF_DEFAULT_OPS`.

I found out that certain operations would not work with my default `FZF_DEFAULT_OPS` value.

For example:
Having the option `-1` (or `--select-1`) will make `extracto`'s pop-up disappear immediately when there is 0 or just 1 match thus preventing you from switching to another filter.

## Support other modes
Extra modes added:
- path
- url
- quote
- s-quote

## Cosmetics
Add `--word` as a parameter for the sake of consistency.

## How to try?
Before this PR:
```
set -g @extrakto_filter_order "url line quote s-quote word path all"
```
And no matter what you did, the filters would always be: `word all line`

Now calling `extracto` will give you the `url` filter as default as expected.