### PR TITLE
feat: add an optional second parameter to trigger extrakto with a spe…

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -163,7 +163,7 @@ get_next_mode() {
 
     local next=$1
     if [ $next == "initial" ]; then
-        echo ${modes_list[0]}
+        echo ${EXTRAKTO_INITAL_MODE:-${modes_list[0]}}
     else
         echo ${next_mode[$next]}
     fi

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -163,7 +163,7 @@ get_next_mode() {
 
     local next=$1
     if [ $next == "initial" ]; then
-        echo ${EXTRAKTO_INITAL_MODE:-${modes_list[0]}}
+        echo ${extrakto_inital_mode:-${modes_list[0]}}
     else
         echo ${next_mode[$next]}
     fi

--- a/scripts/open.sh
+++ b/scripts/open.sh
@@ -8,6 +8,17 @@ extrakto="$current_dir/extrakto.sh"
 pane_id=$1
 split_direction=$(get_option "@extrakto_split_direction")
 
+filter="$2"
+if [[ -n "$filter" ]]; then
+    current_filter_order="$(get_option "@extrakto_filter_order")"
+    tmux set-option -g "@extrakto_filter_order" "$filter"
+    function restore_original() {
+        tmux set-option -g "@extrakto_filter_order" "$current_filter_order"
+    }
+
+    trap restore_original EXIT
+fi
+
 if [[ $split_direction == a ]]; then
     if [[ -n $(tmux list-commands popup) ]]; then
         split_direction=p

--- a/scripts/open.sh
+++ b/scripts/open.sh
@@ -8,7 +8,7 @@ extrakto="$current_dir/extrakto.sh"
 pane_id=$1
 split_direction=$(get_option "@extrakto_split_direction")
 
-EXTRAKTO_INITAL_MODE="$2"
+extrakto_inital_mode="$2"
 if [[ $split_direction == a ]]; then
     if [[ -n $(tmux list-commands popup) ]]; then
         split_direction=p
@@ -27,7 +27,7 @@ if [[ $split_direction == p ]]; then
             -h ${popup_height:-$popup_width} \
             -x ${popup_x} \
             -y ${popup_y:-$popup_x} \
-            -e EXTRAKTO_INITAL_MODE="${EXTRAKTO_INITAL_MODE}" \
+            -e extrakto_inital_mode="${extrakto_inital_mode}" \
             -E "${extrakto} ${pane_id} popup"
         rc=$?
     done
@@ -36,6 +36,6 @@ else
     split_size=$(get_option "@extrakto_split_size")
     tmux split-window \
         -${split_direction} \
-        -e EXTRAKTO_INITAL_MODE="${EXTRAKTO_INITAL_MODE}" \
+        -e extrakto_inital_mode="${extrakto_inital_mode}" \
         -l ${split_size} "tmux setw remain-on-exit off; ${extrakto} ${pane_id} split"
 fi

--- a/scripts/open.sh
+++ b/scripts/open.sh
@@ -8,17 +8,7 @@ extrakto="$current_dir/extrakto.sh"
 pane_id=$1
 split_direction=$(get_option "@extrakto_split_direction")
 
-filter="$2"
-if [[ -n "$filter" ]]; then
-    current_filter_order="$(get_option "@extrakto_filter_order")"
-    tmux set-option -g "@extrakto_filter_order" "$filter"
-    function restore_original() {
-        tmux set-option -g "@extrakto_filter_order" "$current_filter_order"
-    }
-
-    trap restore_original EXIT
-fi
-
+EXTRAKTO_INITAL_MODE="$2"
 if [[ $split_direction == a ]]; then
     if [[ -n $(tmux list-commands popup) ]]; then
         split_direction=p
@@ -37,11 +27,15 @@ if [[ $split_direction == p ]]; then
             -h ${popup_height:-$popup_width} \
             -x ${popup_x} \
             -y ${popup_y:-$popup_x} \
+            -e EXTRAKTO_INITAL_MODE="${EXTRAKTO_INITAL_MODE}" \
             -E "${extrakto} ${pane_id} popup"
         rc=$?
     done
     exit $rc
 else
     split_size=$(get_option "@extrakto_split_size")
-    tmux split-window -${split_direction} -l ${split_size} "tmux setw remain-on-exit off; ${extrakto} ${pane_id} split"
+    tmux split-window \
+        -${split_direction} \
+        -e EXTRAKTO_INITAL_MODE="${EXTRAKTO_INITAL_MODE}" \
+        -l ${split_size} "tmux setw remain-on-exit off; ${extrakto} ${pane_id} split"
 fi


### PR DESCRIPTION
This allow us to trigger `extrakto` with a specific filter in mind.

For example running `open.sh 0 url` will open with the `url` filter (and only that one):
![image](https://github.com/laktak/extrakto/assets/3227746/03df34a7-9788-4473-b2be-83c03117f42f)

Thanks to the `restore_original()` function, our settings for `extrakto` will remain the same.

This opens the possibility of having custom key-bindings like:
```
tmux bind-key u run-shell "\"$extrakto_open\" \"#{pane_id}\" url"
```
To trigger `extracto` with our needed filter in mind :-)