### PR TITLE
Define minimum length per filter

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -5,7 +5,7 @@ You can give feedback or star extrakto at https://github.com/laktak/extrakto
 Extrakto uses fzf. You only need to type a few keys to find your selection with a fuzzy match.
 
 - Press *ctrl-f* to change to the next filter mode (*filter_key*)
-  - *word*, the default filter allows you to select words (min length=5)
+  - *word*, the default filter allows you to select words
   - *all*, runs all filters and allows you select quotes, url, paths, etc. \
     You can define your own filters as well.
   - *line*, select full lines

--- a/HELP.md
+++ b/HELP.md
@@ -5,7 +5,7 @@ You can give feedback or star extrakto at https://github.com/laktak/extrakto
 Extrakto uses fzf. You only need to type a few keys to find your selection with a fuzzy match.
 
 - Press *ctrl-f* to change to the next filter mode (*filter_key*)
-  - *word*, the default filter allows you to select words
+  - *word*, the default filter allows you to select words (default min length=5)
   - *all*, runs all filters and allows you select quotes, url, paths, etc. \
     You can define your own filters as well.
   - *line*, select full lines

--- a/extrakto.conf
+++ b/extrakto.conf
@@ -8,13 +8,14 @@
 
 # define a section per filter
 # each filter must have at least a regex containing one or more capture groups
-# regex:   a python regex expression
-# enabled: is filter active (default True)
-# in_all:  is included in --all (default True)
-# lstrip:  characters to strip from left result
-# rstrip:  characters to strip from right result
-# exclude: exclude result if matching
-# alt2-9:  alternate result (see url)
+# regex:      a python regex expression
+# enabled:    is filter active (default True)
+# in_all:     is included in --all (default True)
+# lstrip:     characters to strip from left result
+# rstrip:     characters to strip from right result
+# exclude:    exclude result if matching
+# alt2-9:     alternate result (see url)
+# min_length: minimum length of the result (default 5)
 
 [word]
 # "words" consist of anything but the following characters:

--- a/extrakto.py
+++ b/extrakto.py
@@ -90,7 +90,16 @@ class Extrakto:
 
 class FilterDef:
     def __init__(
-        self, extrakto, name, *, regex, exclude, lstrip, rstrip, alt, min_length
+        self,
+        extrakto,
+        name,
+        *,
+        regex,
+        exclude,
+        lstrip,
+        rstrip,
+        alt,
+        min_length=MIN_LENGTH_DEFAULT,
     ):
         self.extrakto = extrakto
         self.name = name

--- a/extrakto.py
+++ b/extrakto.py
@@ -25,6 +25,7 @@ RE_WORD = "[^][(){}=$\u2500-\u27BF\uE000-\uF8FF \\t\\n\\r]+"
 
 MIN_LENGTH_DEFAULT = 5
 
+
 class ExtraktoException(Exception):
     pass
 
@@ -72,7 +73,7 @@ class Extrakto:
                     lstrip=sect.get("lstrip", ""),
                     rstrip=sect.get("rstrip", ""),
                     alt=alt,
-                    min_length=sect.getint("min_length", MIN_LENGTH_DEFAULT)
+                    min_length=sect.getint("min_length", MIN_LENGTH_DEFAULT),
                 )
 
     def __getitem__(self, key):
@@ -88,7 +89,9 @@ class Extrakto:
 
 
 class FilterDef:
-    def __init__(self, extrakto, name, *, regex, exclude, lstrip, rstrip, alt, min_length):
+    def __init__(
+        self, extrakto, name, *, regex, exclude, lstrip, rstrip, alt, min_length
+    ):
         self.extrakto = extrakto
         self.name = name
         self.regex = regex
@@ -115,7 +118,11 @@ class FilterDef:
                 item = item.rstrip(self.rstrip)
 
             # prefer global min_length, fallback to filter specific
-            if len(item) >= (self.extrakto.min_length if self.extrakto.min_length is not None else self.min_length):
+            if len(item) >= (
+                self.extrakto.min_length
+                if self.extrakto.min_length is not None
+                else self.min_length
+            ):
                 if not self.exclude or not re.search(self.exclude, item, re.I):
                     if self.extrakto.alt:
                         for i, altre in enumerate(self.alt):
@@ -213,9 +220,7 @@ if __name__ == "__main__":
 
     parser.add_argument("-r", "--reverse", action="store_true", help="reverse output")
 
-    parser.add_argument(
-        "-m", "--min-length", help="minimum token length", type=int
-    )
+    parser.add_argument("-m", "--min-length", help="minimum token length", type=int)
 
     parser.add_argument(
         "--warn-empty", action="store_true", help="warn if result is empty"

--- a/extrakto.py
+++ b/extrakto.py
@@ -73,7 +73,12 @@ class Extrakto:
                     lstrip=sect.get("lstrip", ""),
                     rstrip=sect.get("rstrip", ""),
                     alt=alt,
-                    min_length=sect.getint("min_length", MIN_LENGTH_DEFAULT),
+                    # prefer global min_length, fallback to filter specific
+                    min_length=(
+                        self.min_length
+                        if self.min_length is not None
+                        else sect.getint("min_length", MIN_LENGTH_DEFAULT)
+                    ),
                 )
 
     def __getitem__(self, key):
@@ -126,12 +131,7 @@ class FilterDef:
             if self.rstrip:
                 item = item.rstrip(self.rstrip)
 
-            # prefer global min_length, fallback to filter specific
-            if len(item) >= (
-                self.extrakto.min_length
-                if self.extrakto.min_length is not None
-                else self.min_length
-            ):
+            if len(item) >= self.min_length:
                 if not self.exclude or not re.search(self.exclude, item, re.I):
                     if self.extrakto.alt:
                         for i, altre in enumerate(self.alt):

--- a/extrakto.py
+++ b/extrakto.py
@@ -23,6 +23,7 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 # and whitespace ( \t\n\r)
 RE_WORD = "[^][(){}=$\u2500-\u27BF\uE000-\uF8FF \\t\\n\\r]+"
 
+MIN_LENGTH_DEFAULT = 5
 
 class ExtraktoException(Exception):
     pass
@@ -70,7 +71,7 @@ class Extrakto:
                     lstrip=sect.get("lstrip", ""),
                     rstrip=sect.get("rstrip", ""),
                     alt=alt,
-                    min_length=sect.getint("min_length", 5)
+                    min_length=sect.getint("min_length", MIN_LENGTH_DEFAULT)
                 )
 
     def __getitem__(self, key):
@@ -123,7 +124,7 @@ class FilterDef:
         return res
 
 
-def get_lines(text, *, min_length=5, prefix_name=False):
+def get_lines(text, *, min_length=MIN_LENGTH_DEFAULT, prefix_name=False):
     lines = []
 
     for raw_line in text.splitlines():
@@ -211,7 +212,7 @@ if __name__ == "__main__":
     parser.add_argument("-r", "--reverse", action="store_true", help="reverse output")
 
     parser.add_argument(
-        "-m", "--min-length", default=5, help="minimum token length", type=int
+        "-m", "--min-length", default=MIN_LENGTH_DEFAULT, help="minimum token length", type=int
     )
 
     parser.add_argument(

--- a/extrakto_plugin.py
+++ b/extrakto_plugin.py
@@ -78,12 +78,12 @@ def get_cap(mode, data):
     run_list = []
 
     if mode == "all":
-        extrakto = Extrakto(min_length=5, alt=True, prefix_name=True)
+        extrakto = Extrakto(alt=True, prefix_name=True)
         run_list = extrakto.all()
     elif mode == "line":
         res += get_lines(data)
     else:
-        extrakto = Extrakto(min_length=5)
+        extrakto = Extrakto()
         run_list = [mode]
 
     for name in run_list:

--- a/extrakto_plugin.py
+++ b/extrakto_plugin.py
@@ -78,12 +78,12 @@ def get_cap(mode, data):
     run_list = []
 
     if mode == "all":
-        extrakto = Extrakto(alt=True, prefix_name=True)
+        extrakto = Extrakto(min_length=5, alt=True, prefix_name=True)
         run_list = extrakto.all()
     elif mode == "line":
         res += get_lines(data)
     else:
-        extrakto = Extrakto()
+        extrakto = Extrakto(min_length=5)
         run_list = [mode]
 
     for name in run_list:

--- a/tests/test_get_words.py
+++ b/tests/test_get_words.py
@@ -5,7 +5,7 @@ import unittest
 
 from extrakto import Extrakto
 
-get_words = Extrakto()["word"].filter
+get_words = Extrakto(min_length=5)["word"].filter
 
 
 class TestGetWords(unittest.TestCase):

--- a/tests/test_get_words.py
+++ b/tests/test_get_words.py
@@ -5,7 +5,7 @@ import unittest
 
 from extrakto import Extrakto
 
-get_words = Extrakto(min_length=5)["word"].filter
+get_words = Extrakto()["word"].filter
 
 
 class TestGetWords(unittest.TestCase):


### PR DESCRIPTION
Currently, extracto uses the same minimum length for all filters. This PR introduces an optional config key to change the minimum length for each filter individually. The default value is still five, though.