### PR TITLE
fix using wrong encoding on Windows

### DIFF
--- a/extrakto.py
+++ b/extrakto.py
@@ -38,7 +38,7 @@ class Extrakto:
             os.path.expanduser("~/.config"), "extrakto/extrakto.conf"
         )
 
-        conf.read([default_conf, user_conf])
+        conf.read([default_conf, user_conf], encoding="utf-8")
         sections = conf.sections()
 
         if not "path" in sections or not "url" in sections:

--- a/extrakto_plugin.py
+++ b/extrakto_plugin.py
@@ -238,6 +238,7 @@ class ExtraktoPlugin:
                 self.trigger_pane,
             ],
             universal_newlines=True,
+            encoding="utf-8",
         )
         return captured
 


### PR DESCRIPTION
Hello, I'm using tmux installed with MSYS2 and Python installed with pyenv-win on Windows 11.
In this environment, extracto fails with the following error:
```
['fzf', '--multi', '--print-query', '--query=', '--header=\x1b[1menter\x1b[0m=insert, \x1b[1mtab\x1b[0m=copy, \x1b[1m^o\x1b[0m=open, \x1b[1m^e\x1b[0m=edit, \x1b[1m^f\x1b[0m=filter [\x1b[0;33m\x1b[1mword\x1b[0m], \x1b[1m^g\x1b[0m=grab [\x1b[0;33m\x1b[1mwindow full\x1b[0m], \x1b[1m^h\x1b[0m=help', '--expect=ctrl-c,ctrl-g,esc', '--expect=enter,tab,ctrl-f,ctrl-e,ctrl-o,ctrl-g,ctrl-h', '--tiebreak=index', '--layout=default', '--no-info']
Traceback (most recent call last):
  File "C:\msys64\home\shach\.tmux\plugins\extrakto\extrakto_plugin.py", line 315, in capture
    get_cap(mode, self.capture_panes()),
                  ^^^^^^^^^^^^^^^^^^^^
  File "C:\msys64\home\shach\.tmux\plugins\extrakto\extrakto_plugin.py", line 231, in capture_panes
    captured += subprocess.check_output(
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\shach\.pyenv\pyenv-win\versions\3.12.6\Lib\subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\shach\.pyenv\pyenv-win\versions\3.12.6\Lib\subprocess.py", line 550, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\shach\.pyenv\pyenv-win\versions\3.12.6\Lib\subprocess.py", line 1196, in communicate
    stdout = self.stdout.read()
             ^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'cp932' codec can't decode byte 0xef in position 45: illegal multibyte sequence

error: unable to extract - check/report errors above
If fzf is not found you need to set the fzf path in options (see readme).
```
Note that cp932 is ANSI encoding on Japanese Windows, which is used in Python by default.

Explicitly specifying encoding as utf-8 fixed this error and I could use extracto on Windows.
I think this doesn't affect other environments like Linux or MacOS because utf-8 should be default there.
