### PR TITLE
feat: add @extrakto_alt and @extrakto_prefix_name options

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ All but `@extrakto_key` are controlled by fzf and must follow its conventions.
 | `@extrakto_popup_size`                | `90%`           | Set width and height of the tmux popup window. Set this to `w,h` to set the width to `w` and height to `h`. |
 | `@extrakto_split_direction`           | `a`             | Whether the tmux split will be `a`uto, `p`opup, `v`ertical or `h`orizontal |
 | `@extrakto_split_size`                | `7`             | The size of the tmux split (for vertical/horizontal) |
+| `@extrakto_alt`                       | `false`         | Set this is you want to show alternatives on all filters and not just for `all` |
+| `@extrakto_prefix_name`               | `false`         | Set this is you want to prefix the results with the filter name |
 
 ### Using skim instead of fzf
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ All but `@extrakto_key` are controlled by fzf and must follow its conventions.
 | `@extrakto_popup_size`                | `90%`           | Set width and height of the tmux popup window. Set this to `w,h` to set the width to `w` and height to `h`. |
 | `@extrakto_split_direction`           | `a`             | Whether the tmux split will be `a`uto, `p`opup, `v`ertical or `h`orizontal |
 | `@extrakto_split_size`                | `7`             | The size of the tmux split (for vertical/horizontal) |
-| `@extrakto_alt`                       | `false`         | Set this is you want to show alternatives on all filters and not just for `all` |
-| `@extrakto_prefix_name`               | `false`         | Set this is you want to prefix the results with the filter name |
+| `@extrakto_alt`                       | `all`           | Show alternative filters. Possible values are: `all` to only show them for the all filter, `any` for any filter and `none` for never. |
+| `@extrakto_prefix_name`               | `all`           | Prefix the results with the filter name. Possible values are: `all` to only show the prefix for the all filter, `any` for any filter and `none` for never. |
 
 ### Using skim instead of fzf
 

--- a/extrakto.py
+++ b/extrakto.py
@@ -21,7 +21,7 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 # - Dingbats
 # unicode range E000-F8FF (private use/Powerline)
 # and whitespace ( \t\n\r)
-RE_WORD = "[^][(){}=$\u2500-\u27BF\uE000-\uF8FF \\t\\n\\r]+"
+RE_WORD = "[^][(){}=$\u2500-\u27bf\ue000-\uf8ff \\t\\n\\r]+"
 
 MIN_LENGTH_DEFAULT = 5
 

--- a/extrakto_plugin.py
+++ b/extrakto_plugin.py
@@ -337,12 +337,14 @@ class ExtraktoPlugin:
                     self.copy(msg)
                 sys.exit(0)
 
+            # selection will be without or with the filter name prefixing the entry
+            # "example quoted text here"
+            # quote: "example quoted text here"
             text = ""
-            if mode == "all":
-                text = "\n".join(
-                    next(iter(s.split(": ", 1)[1:2]), s) for s in selection
-                )
-            elif mode == "line":
+            if self.prefix_name == "true" or mode == "all":
+                selection = [next(iter(s.split(": ", 1)[1:2]), s) for s in selection]
+
+            if mode in ("all", "line"):
                 text = "\n".join(selection)
             else:
                 text = " ".join(selection)

--- a/extrakto_plugin.py
+++ b/extrakto_plugin.py
@@ -46,8 +46,8 @@ DEFAULT_OPTIONS = {
     "@extrakto_insert_key": "tab",
     "@extrakto_open_key": "ctrl-o",
     "@extrakto_open_tool": "auto",
-    "@extrakto_alt": "false",
-    "@extrakto_prefix_name": "false",
+    "@extrakto_alt": "all",
+    "@extrakto_prefix_name": "all",
 }
 
 
@@ -79,16 +79,22 @@ def get_cap(mode, data):
     extrakto = None
     res = []
     run_list = []
-    alt = True if get_option("@extrakto_alt") == "true" else False
-    prefix_name = True if get_option("@extrakto_prefix_name") == "true" else False
+    alt = get_option("@extrakto_alt")
+    prefix_name = get_option("@extrakto_prefix_name")
 
     if mode == "all":
-        extrakto = Extrakto(alt=True, prefix_name=True)
+        extrakto = Extrakto(
+            alt=(True if alt != "none" else False),
+            prefix_name=(True if prefix_name != "none" else False),
+        )
         run_list = extrakto.all()
     elif mode == "line":
         res += get_lines(data)
     else:
-        extrakto = Extrakto(alt=alt, prefix_name=prefix_name)
+        extrakto = Extrakto(
+            alt=(True if alt == "any" else False),
+            prefix_name=(True if prefix_name == "any" else False),
+        )
         run_list = [mode]
 
     for name in run_list:
@@ -341,7 +347,9 @@ class ExtraktoPlugin:
             # "example quoted text here"
             # quote: "example quoted text here"
             text = ""
-            if self.prefix_name == "true" or mode == "all":
+            if (
+                self.prefix_name == "all" and mode == "all"
+            ) or self.prefix_name == "any":
                 selection = [next(iter(s.split(": ", 1)[1:2]), s) for s in selection]
 
             if mode in ("all", "line"):

--- a/extrakto_plugin.py
+++ b/extrakto_plugin.py
@@ -46,6 +46,8 @@ DEFAULT_OPTIONS = {
     "@extrakto_insert_key": "tab",
     "@extrakto_open_key": "ctrl-o",
     "@extrakto_open_tool": "auto",
+    "@extrakto_alt": "false",
+    "@extrakto_prefix_name": "false",
 }
 
 
@@ -77,6 +79,8 @@ def get_cap(mode, data):
     extrakto = None
     res = []
     run_list = []
+    alt = True if get_option("@extrakto_alt") == "true" else False
+    prefix_name = True if get_option("@extrakto_prefix_name") == "true" else False
 
     if mode == "all":
         extrakto = Extrakto(alt=True, prefix_name=True)
@@ -84,7 +88,7 @@ def get_cap(mode, data):
     elif mode == "line":
         res += get_lines(data)
     else:
-        extrakto = Extrakto()
+        extrakto = Extrakto(alt=alt, prefix_name=prefix_name)
         run_list = [mode]
 
     for name in run_list:
@@ -118,6 +122,8 @@ class ExtraktoPlugin:
         self.insert_key = get_option("@extrakto_insert_key")
         self.open_key = get_option("@extrakto_open_key")
         self.open_tool = get_option("@extrakto_open_tool")
+        self.alt = get_option("@extrakto_alt")
+        self.prefix_name = get_option("@extrakto_prefix_name")
 
         self.original_grab_area = self.grab_area
 


### PR DESCRIPTION
By default, extrakto_plugin is only showing alternative options to filters and prefixing the results with the name filter whenever we trigger the `all` filters option.

extrakto provides us the option to enable or disable both the filter alternatives and the prefixing of the names.

This code allows this option in our plugin.

The code has been modified to follow what was suggested by @laktak in his [comment](https://github.com/laktak/extrakto/pull/133#issuecomment-3104712525)

| Option                                | Default         | Description |
| :---                                  | :---:           | :--- |
| `@extrakto_alt`                       | `all`           | Show alternative filters. Possible values are: `all` to only show them for the all filter, `any` for any filter and `none` for never. |
| `@extrakto_prefix_name`               | `all`           | Prefix the results with the filter name. Possible values are: `all` to only show the prefix for the all filter, `any` for any filter and `none` for never. |


Important note: this code does **not** affect the `line` filter ( haven't dig through the code enough to know why this one behaves a bit differently 😅 )