### PR TITLE
feat: add hotkey to toggle clipboard mode with configurable cycle order

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -17,6 +17,12 @@ Extrakto uses fzf. You only need to type a few keys to find your selection with 
   - *recent*, everything visible with a few lines from the history (current pane)
   - *window recent*, everything visible with a few lines from the history (window)
 
+- Press *ctrl-s* to toggle clipboard mode (*clip_toggle_key*)
+  - Cycles through modes in order defined by *clip_tool_run_order* (default: bg -> tmux_osc52 -> buffer)
+  - *buffer*: only save to tmux buffer, no clipboard (paste with prefix + ])
+  - *bg/fg*: copy to system clipboard using your configured clipboard tool
+  - *tmux_osc52*: copy to remote clipboard via OSC 52 (useful over SSH)
+
 - Press *esc* or *ctrl-c* to cancel
 
 - Use *shift-tab* to select multiple entries.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Where `<option>` and `<value>` correspond to one of the options specified below
 | `@extrakto_grab_key`                  | `ctrl-g`        | Key to toggle grab mode. |
 | `@extrakto_edit_key`                  | `ctrl-e`        | Key to run the editor. |
 | `@extrakto_open_key`                  | `ctrl-o`        | Key to run the open command. |
+| `@extrakto_clip_toggle_key`           | `ctrl-s`        | Key to cycle clipboard mode between `buffer` (tmux buffer only), your configured `@extrakto_clip_tool_run` value, and `tmux_osc52`. Useful when you don't want to pollute your clipboard history. |
 
 All but `@extrakto_key` are controlled by fzf and must follow its conventions.
 
@@ -127,12 +128,13 @@ All but `@extrakto_key` are controlled by fzf and must follow its conventions.
 
 | Option                                | Default         | Description |
 | :---                                  | :---:           | :--- |
-| `@extrakto_clip_tool_run`             | `bg`            | Set this to `tmux_osc52` to enable [remote clipboard support](https://github.com/laktak/extrakto/wiki/Remote-Copy-via-OSC52) or `fg`/`bg` to have your clipboard tool run in a foreground/background shell. |
+| `@extrakto_clip_tool_run`             | `bg`            | Set this to `tmux_osc52` to enable [remote clipboard support](https://github.com/laktak/extrakto/wiki/Remote-Copy-via-OSC52), `fg`/`bg` to have your clipboard tool run in a foreground/background shell, or `buffer` to only save to tmux buffer without copying to clipboard. Note: if `@extrakto_clip_tool_run_order` is set, the first value in that list is used as default instead. |
+| `@extrakto_clip_tool_run_order`       | `bg tmux_osc52 buffer` | Order of clipboard modes to cycle through with `@extrakto_clip_toggle_key`. The first mode becomes the default. Omit modes you don't want in the cycle. Valid modes: `bg`, `fg`, `tmux_osc52`, `buffer`. |
 | `@extrakto_clip_tool`                 | `auto`          | Set this to whatever clipboard tool you would like extrakto to use to copy data into your clipboard. `auto` will try to choose the correct clipboard for your platform. |
 | `@extrakto_editor`                    |                 | This defaults to `$EDITOR` if not set. |
 | `@extrakto_fzf_layout`                |`default`        | Control the fzf layout which is "bottom-up" by default. If you prefer "top-down" layout instead set this to `reverse`. In fact, this value is passed to the fzf `--layout` parameter. Possible values are: `default`, `reverse` and `reverse-list` |
 | `@extrakto_fzf_tool`                  | `fzf`           | Set this to path of fzf if it can't be found in your `PATH`. If you prefer skim you need to set this option to `sk` or its full path. |
-| `@extrakto_fzf_header`                | `i c o e f g h` | Define the fzf header to show keys for insert, copy, open, edit, filter, grab and help. You can reorder or omit information you don't need.|
+| `@extrakto_fzf_header`                | `i c o e f g h` | Define the fzf header to show keys for insert, copy, open, edit, filter, grab, clip (s) and help. You can reorder or omit information you don't need.|
 | `@extrakto_fzf_unset_default_opts`    | `true`          | Unsets custom FZF_DEFAULT_OPTS as it can potentially cause problems in extrakto operations |
 | `@extrakto_open_tool`                 | `auto`          | Set this to path of your own tool or `auto` to use your platforms *open* implementation. |
 | `@extrakto_popup_position`            | `C`             | Set position of the tmux popup window. Possible values are in the `display-popup` entry in `man tmux`. Set this to `x,y` to set the x and y positions to `x` and `y` respectively. |

--- a/extrakto_plugin.py
+++ b/extrakto_plugin.py
@@ -31,6 +31,8 @@ COLORS = {
 DEFAULT_OPTIONS = {
     "@extrakto_clip_tool": "auto",
     "@extrakto_clip_tool_run": "bg",
+    "@extrakto_clip_tool_run_order": "bg tmux_osc52 buffer",
+    "@extrakto_clip_toggle_key": "ctrl-s",
     "@extrakto_copy_key": "enter",
     "@extrakto_edit_key": "ctrl-e",
     "@extrakto_filter_key": "ctrl-f",
@@ -115,6 +117,7 @@ class ExtraktoPlugin:
         # options; note some of the values can be overwritten by capture()
         self.clip_tool = get_option("@extrakto_clip_tool")
         self.clip_tool_run = get_option("@extrakto_clip_tool_run")
+        self.clip_toggle_key = get_option("@extrakto_clip_toggle_key")
         self.copy_key = get_option("@extrakto_copy_key")
         self.edit_key = get_option("@extrakto_edit_key")
         self.editor = get_option("@extrakto_editor")
@@ -140,6 +143,18 @@ class ExtraktoPlugin:
                 self.next_mode[self.modes_list[i]] = self.modes_list[0]
             else:
                 self.next_mode[self.modes_list[i]] = self.modes_list[i + 1]
+
+        # clip tool run order (for cycling with clip_toggle_key)
+        self.clip_modes_list = get_option("@extrakto_clip_tool_run_order").split(" ")
+        self.next_clip_mode = {}
+        for i in range(len(self.clip_modes_list)):
+            if i == len(self.clip_modes_list) - 1:
+                self.next_clip_mode[self.clip_modes_list[i]] = self.clip_modes_list[0]
+            else:
+                self.next_clip_mode[self.clip_modes_list[i]] = self.clip_modes_list[i + 1]
+        # use first in order as default, or fall back to configured value
+        if self.clip_modes_list:
+            self.clip_tool_run = self.clip_modes_list[0]
 
         # avoid side effects from FZF_DEFAULT_OPTS
         if get_option("@extrakto_fzf_unset_default_opts") == "true":
@@ -183,6 +198,9 @@ class ExtraktoPlugin:
         elif self.clip_tool_run == "tmux_osc52":
             # use native tmux 3.2 OSC 52 functionality
             subprocess.run(["tmux", "set-buffer", "-w", "--", text], check=True)
+        elif self.clip_tool_run == "buffer":
+            # only save to tmux buffer, no clipboard
+            subprocess.run(["tmux", "set-buffer", "--", text], check=True)
         else:
             # run in background as xclip won't work otherwise
             subprocess.run(["tmux", "set-buffer", "--", text], check=True)
@@ -298,6 +316,8 @@ class ExtraktoPlugin:
                 header_tmpl += f"{COLORS['BOLD']}{self.grab_key}{COLORS['OFF']}=grab [{COLORS['YELLOW']}{COLORS['BOLD']}:ga:{COLORS['OFF']}]"
             elif o == "h":
                 header_tmpl += f"{COLORS['BOLD']}{self.help_key}{COLORS['OFF']}=help"
+            elif o == "s":
+                header_tmpl += f"{COLORS['BOLD']}{self.clip_toggle_key}{COLORS['OFF']}=clip [{COLORS['YELLOW']}{COLORS['BOLD']}:clip:{COLORS['OFF']}]"
             else:
                 header_tmpl += "(config error)"
 
@@ -306,6 +326,7 @@ class ExtraktoPlugin:
             header = (
                 header_tmpl.replace(":ga:", self.grab_area)
                 .replace(":filter:", mode)
+                .replace(":clip:", self.clip_tool_run)
                 .replace("ctrl-", "^")
             )
 
@@ -318,7 +339,7 @@ class ExtraktoPlugin:
                     f"--query={query}",
                     f"--header={header}",
                     f"--expect=ctrl-c,ctrl-g,esc",
-                    f"--expect={self.insert_key},{self.copy_key},{self.filter_key},{self.edit_key},{self.open_key},{self.grab_key},{self.help_key}",
+                    f"--expect={self.insert_key},{self.copy_key},{self.filter_key},{self.edit_key},{self.open_key},{self.grab_key},{self.help_key},{self.clip_toggle_key}",
                     "--tiebreak=index",
                     f"--layout={self.fzf_layout}",
                     "--no-info",
@@ -429,6 +450,13 @@ class ExtraktoPlugin:
                     self.open(PRJ_URL)
                 elif confirm == "c":
                     self.copy(PRJ_URL)
+            elif key == self.clip_toggle_key:
+                # cycle through clip modes based on configured order
+                if self.clip_tool_run in self.next_clip_mode:
+                    self.clip_tool_run = self.next_clip_mode[self.clip_tool_run]
+                else:
+                    # fallback to first in list if current mode not in cycle
+                    self.clip_tool_run = self.clip_modes_list[0]
             else:
                 return 0
 

--- a/tests/test_clip_mode.py
+++ b/tests/test_clip_mode.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+
+
+def build_clip_mode_cycle(order_string):
+    """Build the next_clip_mode dictionary from an order string."""
+    modes_list = order_string.split(" ")
+    next_mode = {}
+    for i in range(len(modes_list)):
+        if i == len(modes_list) - 1:
+            next_mode[modes_list[i]] = modes_list[0]
+        else:
+            next_mode[modes_list[i]] = modes_list[i + 1]
+    return modes_list, next_mode
+
+
+def get_next_clip_mode(current_mode, modes_list, next_mode):
+    """Get the next clip mode in the cycle."""
+    if current_mode in next_mode:
+        return next_mode[current_mode]
+    else:
+        # fallback to first in list if current mode not in cycle
+        return modes_list[0]
+
+
+class TestClipModeCycle(unittest.TestCase):
+    def test_default_order_cycle(self):
+        """Test default order: bg -> tmux_osc52 -> buffer -> bg"""
+        modes_list, next_mode = build_clip_mode_cycle("bg tmux_osc52 buffer")
+
+        self.assertEqual(modes_list[0], "bg")
+        self.assertEqual(next_mode["bg"], "tmux_osc52")
+        self.assertEqual(next_mode["tmux_osc52"], "buffer")
+        self.assertEqual(next_mode["buffer"], "bg")
+
+    def test_custom_order_buffer_first(self):
+        """Test custom order: buffer -> tmux_osc52 -> bg -> buffer"""
+        modes_list, next_mode = build_clip_mode_cycle("buffer tmux_osc52 bg")
+
+        self.assertEqual(modes_list[0], "buffer")
+        self.assertEqual(next_mode["buffer"], "tmux_osc52")
+        self.assertEqual(next_mode["tmux_osc52"], "bg")
+        self.assertEqual(next_mode["bg"], "buffer")
+
+    def test_two_modes_only(self):
+        """Test with only two modes: buffer -> tmux_osc52 -> buffer"""
+        modes_list, next_mode = build_clip_mode_cycle("buffer tmux_osc52")
+
+        self.assertEqual(len(modes_list), 2)
+        self.assertEqual(modes_list[0], "buffer")
+        self.assertEqual(next_mode["buffer"], "tmux_osc52")
+        self.assertEqual(next_mode["tmux_osc52"], "buffer")
+
+    def test_single_mode_no_cycle(self):
+        """Test with single mode - cycles back to itself"""
+        modes_list, next_mode = build_clip_mode_cycle("buffer")
+
+        self.assertEqual(len(modes_list), 1)
+        self.assertEqual(modes_list[0], "buffer")
+        self.assertEqual(next_mode["buffer"], "buffer")
+
+    def test_get_next_mode_in_cycle(self):
+        """Test getting next mode when current is in cycle"""
+        modes_list, next_mode = build_clip_mode_cycle("buffer tmux_osc52 bg")
+
+        self.assertEqual(get_next_clip_mode("buffer", modes_list, next_mode), "tmux_osc52")
+        self.assertEqual(get_next_clip_mode("tmux_osc52", modes_list, next_mode), "bg")
+        self.assertEqual(get_next_clip_mode("bg", modes_list, next_mode), "buffer")
+
+    def test_get_next_mode_not_in_cycle(self):
+        """Test fallback to first mode when current is not in cycle"""
+        modes_list, next_mode = build_clip_mode_cycle("buffer tmux_osc52")
+
+        # "bg" is not in the cycle, should fallback to first (buffer)
+        self.assertEqual(get_next_clip_mode("bg", modes_list, next_mode), "buffer")
+        self.assertEqual(get_next_clip_mode("fg", modes_list, next_mode), "buffer")
+
+    def test_full_cycle_iteration(self):
+        """Test iterating through a full cycle"""
+        modes_list, next_mode = build_clip_mode_cycle("buffer tmux_osc52 bg")
+
+        current = modes_list[0]  # Start with default (buffer)
+        visited = [current]
+
+        # Cycle through all modes
+        for _ in range(len(modes_list)):
+            current = get_next_clip_mode(current, modes_list, next_mode)
+            visited.append(current)
+
+        # Should have visited: buffer -> tmux_osc52 -> bg -> buffer
+        self.assertEqual(visited, ["buffer", "tmux_osc52", "bg", "buffer"])
+
+    def test_fg_mode_in_cycle(self):
+        """Test with fg mode instead of bg"""
+        modes_list, next_mode = build_clip_mode_cycle("buffer tmux_osc52 fg")
+
+        self.assertEqual(modes_list[0], "buffer")
+        self.assertEqual(next_mode["buffer"], "tmux_osc52")
+        self.assertEqual(next_mode["tmux_osc52"], "fg")
+        self.assertEqual(next_mode["fg"], "buffer")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a clipboard mode toggle feature that allows cycling between different copy behaviors at runtime:

- **New key binding**: `@extrakto_clip_toggle_key` (default: `ctrl-s`) to cycle through clipboard modes
- **Configurable cycle order**: `@extrakto_clip_tool_run_order` (default: `bg tmux_osc52 buffer`) - first mode becomes the default
- **New clipboard mode**: `buffer` - only saves to tmux buffer without copying to any clipboard

## Motivation

When using extrakto, every copy operation goes to the system clipboard. This can be problematic when:

1. **Clipboard history pollution**: Users with clipboard managers don't want every temporary copy cluttering their history
2. **Selective remote clipboard**: When SSH'd into a remote machine, users may want to copy to remote clipboard (via OSC 52) only selectively, not every time
3. **Temporary copies**: Sometimes you just want to paste within tmux without affecting the system clipboard

This feature gives users control over copy destination on a per-copy basis.

## New Options

| Option | Default | Description |
|--------|---------|-------------|
| `@extrakto_clip_toggle_key` | `ctrl-s` | Key to cycle clipboard modes |
| `@extrakto_clip_tool_run_order` | `bg tmux_osc52 buffer` | Order of modes to cycle through. First mode is default. Omit modes you don't need. |

## New Clipboard Mode

| Mode | Description |
|------|-------------|
| `buffer` | Only save to tmux buffer, no clipboard (paste with `prefix + ]`) |

## Usage

1. Add `s` to your header to see current mode: `set -g @extrakto_fzf_header "i c f g s h"`
2. Press `ctrl-s` while in extrakto to cycle through modes
3. The header shows current mode: `^s=clip [buffer]`

Example config for buffer-first workflow:
```tmux
set -g @extrakto_clip_tool_run_order "buffer tmux_osc52 bg"
set -g @extrakto_fzf_header "i c f g s h"
```

## Test Plan

- [x] All existing tests pass (14 tests)
- [x] New unit tests for clip mode cycling logic (8 tests)
- [x] Code formatted with `black`
- [x] Manual testing in tmux

## Changes

- `extrakto_plugin.py`: Add new options, `buffer` mode in `copy()`, and toggle key handler
- `README.md`: Document new options
- `HELP.md`: Document new key binding
- `tests/test_clip_mode.py`: New test file with 8 unit tests

🤖 Generated with [Claude Code](https://claude.ai/code)