### PR TITLE
Also ignore FZF_DEFAULT_OPTS_FILE

### DIFF
--- a/extrakto_plugin.py
+++ b/extrakto_plugin.py
@@ -144,6 +144,7 @@ class ExtraktoPlugin:
         # avoid side effects from FZF_DEFAULT_OPTS
         if get_option("@extrakto_fzf_unset_default_opts") == "true":
             os.environ.pop("FZF_DEFAULT_OPTS", None)
+            os.environ.pop("FZF_DEFAULT_OPTS_FILE", None)
 
         if self.clip_tool == "auto":
             if PLATFORM == "Linux":


### PR DESCRIPTION
Pop FZF_DEFAULT_OPTS_FILE from the environment in the same way as FZF_DEFAULT_OPTS.

The FZF_DEFAULT_OPTS_FILE environment variable was added in [fzf 0.47.0](https://github.com/junegunn/fzf/releases/tag/0.47.0)